### PR TITLE
Update Signature Method for Crapple

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -734,7 +734,15 @@ def auth_application(request):
     """
     try:
         signature = request.POST.get("signature")
-        log.debug("signature: %s", signature)
+        log.debug("signature 1: %s", signature)
+        if not signature:
+            body = get_json_body(request)
+            log.debug("body: %s", body)
+            signature = body.get("signature")
+            log.debug("signature 2: %s", signature)
+        if not signature:
+            raise ValueError("No signature provided.")
+        log.debug("signature 3: %s", signature)
         data = verify_signature(signature)
         log.debug("user_id: %s", data["user_id"])
         user = CustomUser.objects.get(id=data["user_id"])

--- a/app/settings/views.py
+++ b/app/settings/views.py
@@ -2,7 +2,7 @@ import json
 import logging
 import zoneinfo
 from datetime import datetime, timedelta
-from urllib.parse import urlencode, urlunparse
+from urllib.parse import quote
 
 import qrcode
 from django.conf import settings
@@ -319,9 +319,11 @@ def get_signed_url(request):
     log.debug("signature: %s", signature)
     data = {"url": site_settings.site_url, "signature": signature}
     log.debug("data: %s", data)
-    base = ("djangofiles", "authorize", "/", "", urlencode(data), "")
-    url = urlunparse(base)
-    log.debug("url: %s", url)
+    scheme = "djangofiles"
+    host = "authorize"
+    path = "/"
+    query = "&".join(f"{quote(k)}={quote(v)}" for k, v in data.items())
+    url = f"{scheme}://{host}{quote(path)}?{query}"
     return url
 
 


### PR DESCRIPTION
- Use `%20` encoding for query params in `/api/auth/application/` endpoint