### PR TITLE
Fix: ASGI websocket double-accept race + ignore benign CancelledError in Sentry

### DIFF
--- a/app/djangofiles/settings.py
+++ b/app/djangofiles/settings.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import os
 import sys
@@ -429,6 +430,9 @@ if config("SENTRY_URL", False):
         send_default_pii=True,
         debug=config("SENTRY_DEBUG", config("DEBUG", "False"), bool),
         environment=config("SENTRY_ENVIRONMENT", None),
+        # A client disconnecting mid-request cancels the ASGI task; the
+        # resulting CancelledError is expected control flow, not a bug.
+        ignore_errors=[asyncio.CancelledError],
     )
 
 if DEBUG:

--- a/app/home/consumers.py
+++ b/app/home/consumers.py
@@ -92,10 +92,17 @@ _ALLOWED_METHODS = frozenset(
 
 class HomeConsumer(AsyncWebsocketConsumer):
     _stream_chat_group = None
+    _accepted = False
 
     async def websocket_connect(self, event):
         log.debug("websocket_connect")
         log.debug(event)
+        if self._accepted:
+            # Duplicate 'websocket.connect' dispatch on an already-accepted
+            # connection; calling accept() again raises a RuntimeError from
+            # the ASGI protocol's state machine, so bail out instead.
+            log.warning("websocket_connect: duplicate connect event, ignoring")
+            return
         await self.channel_layer.group_add("home", self.channel_name)
         user = self.scope["user"]
         if not (hasattr(user, "id") and user.id):
@@ -117,6 +124,7 @@ class HomeConsumer(AsyncWebsocketConsumer):
         session = self.scope.get("session")
         if session and not session.session_key:
             await database_sync_to_async(session.save)()
+        self._accepted = True
         await self.accept()
 
     async def websocket_disconnect(self, event):


### PR DESCRIPTION
Two unrelated Sentry issues, both from the same investigation session.

## 1. `RuntimeError: Expected ASGI message 'websocket.send' or 'websocket.close', but got 'websocket.accept'` in `home.consumers`

This means the ASGI protocol state machine was already past the connect stage (`accept()` had already been sent) when the app called `accept()` again — i.e. `HomeConsumer.websocket_connect` was dispatched twice for the same connection. `websocket_connect` does several `await`s (channel-layer `group_add`, an optional DB token/session lookup) before calling `self.accept()`, widening the window for this. The event coincided with a deploy; a worker restart mid-handshake under gunicorn/UvicornWorker is the likely trigger for the ASGI server replaying the connect message.

**Fix:** made `websocket_connect` idempotent — track `_accepted` on the consumer and short-circuit on a duplicate connect event instead of calling `accept()` a second time and raising.

(Infra side, not part of this PR: worth checking that swarm's `stop_grace_period` for the app service is ≥ gunicorn's `graceful_timeout` so workers get a clean drain window on deploy.)

## 2. `CancelledError` (no message) in `djangofiles/middleware.py` (`SessionRefreshMiddleware`) on `/oauth/`

Not an app bug — `asyncio.CancelledError` is raised when a client disconnects before Django finishes generating a response (tab closed, navigated away, proxy timeout) mid OAuth-redirect. It surfaces inside `SessionRefreshMiddleware` because that middleware is sync and gets wrapped/awaited via `sync_to_async` under ASGI; the cancellation propagates through wherever the event loop happens to be. Since `CancelledError` inherits from `BaseException` (not `Exception`), Django's exception middleware doesn't (and shouldn't) swallow it — that's correct ASGI behavior, not a defect in the middleware or request chain.

**Fix:** added `ignore_errors=[asyncio.CancelledError]` to `sentry_sdk.init()` so expected client disconnects stop being reported as errors.

## Testing

- `ruff check`, `black --check`, `isort --check` pass on both changed files.
- Neither fix is independently reproducible locally (both are races/behavior tied to ASGI-server-level connection lifecycle), so these are defensive/config fixes rather than regression tests.