### PR TITLE
Reduce dev swarm stack memory footprint

### DIFF
--- a/docker-compose-swarm.yaml
+++ b/docker-compose-swarm.yaml
@@ -113,7 +113,9 @@ services:
         - BUILD_SHA=${COMMIT_SHA}
     image: ghcr.io/django-files/django-files-app:${VERSION:-latest}
     environment: *django_env
-    command: "gunicorn djangofiles.asgi:application -b 0.0.0.0:9000 -w 2 -k uvicorn.workers.UvicornWorker"
+    # -w1: the UvicornWorker is async and handles dev's low idle concurrency
+    # fine on its own; a 2nd worker only buys parallelism dev doesn't need.
+    command: "gunicorn djangofiles.asgi:application -b 0.0.0.0:9000 -w 1 -k uvicorn.workers.UvicornWorker"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:9000/app-health-check/"]
       interval: 1m
@@ -127,10 +129,10 @@ services:
           - node.hostname == ${SWARM_NODE}
       resources:
         limits:
-          memory: 1G
+          memory: 512M
           cpus: "2.0"
         reservations:
-          memory: 512M
+          memory: 256M
           cpus: "0.5"
     volumes:
       - static_dir:/data/static
@@ -143,15 +145,19 @@ services:
   worker:
     image: ghcr.io/django-files/django-files-app:${VERSION:-latest}
     environment: *django_env
-    command: "celery -A djangofiles worker -l INFO -c 4"
+    # Autoscale instead of a fixed prefork pool of 4: each forked process is
+    # a full Django import, and dev's task load is idle almost all the time.
+    # Scales up to 4 for real bursts (thumbnail/video generation), back down
+    # to 1 when idle.
+    command: "celery -A djangofiles worker -l INFO --autoscale=4,1"
     deploy:
       replicas: 1
       resources:
         limits:
-          memory: 2G
+          memory: 1G
           cpus: "2.0"
         reservations:
-          memory: 1G
+          memory: 256M
           cpus: "0.5"
     volumes:
       - /data/docker/${STACK_NAME}:/data/media
@@ -239,7 +245,13 @@ services:
 
   redis:
     image: redis:7-alpine
-    command: "redis-server --appendonly yes"
+    # maxmemory-policy noeviction: this instance also serves as the Celery
+    # broker/backend (db1) and Channels layer (db0, shared with cache) —
+    # evicting those keys under memory pressure would silently drop tasks
+    # or websocket group state, so a full instance should fail writes
+    # loudly instead. maxmemory stays under the container's memory limit so
+    # redis enforces the cap itself rather than getting OOM-killed.
+    command: "redis-server --appendonly yes --maxmemory 400mb --maxmemory-policy noeviction"
     deploy:
       replicas: 1
       resources:
@@ -247,7 +259,7 @@ services:
           memory: 512M
           cpus: "0.5"
         reservations:
-          memory: 256M
+          memory: 128M
           cpus: "0.25"
     volumes:
       - /data/docker/${STACK_NAME}/redis:/data


### PR DESCRIPTION
## Problem

Measured live on the swarm dev stack (idle): ~850MB actual RSS against 4.2GB of reserved/limit memory across app+worker+beat+redis+tusd+nginx. `docker service ps` also showed an OOM kill (exit 137) on the `app` service 7 days ago.

Biggest offenders:
- `celery worker -c 4` forks 4 full Django processes even though nearly all tasks are lightweight (websocket pushes, cache invalidation); only thumbnail/video generation is heavy, and video goes through an ffmpeg subprocess.
- `gunicorn -w 2` — the UvicornWorker is async, so a single worker already handles dev's idle-to-light concurrency; the 2nd worker buys parallelism/failover dev doesn't need.
- Redis has no `maxmemory`, so an unbounded cache fill has no eviction policy and no cap — worst case it grows until Docker OOM-kills the container, which also serves as the Celery broker/backend and Channels layer.

## Changes (dev swarm stack only — `docker-compose-swarm.yaml`)

- `app`: `-w 2` → `-w 1`; limit 1G→512M, reservation 512M→256M.
- `worker`: `-c 4` (fixed prefork) → `--autoscale=4,1` (scales down to 1 process idle, up to 4 under real load); limit 2G→1G, reservation 1G→256M.
- `redis`: added `--maxmemory 400mb --maxmemory-policy noeviction` (fails writes loudly instead of risking an OOM kill that could also drop broker/queue data); reservation 256M→128M.
- `beat`, `tusd`, `nginx` left as-is — measured usage already tracks their limits closely.

Net: ~2.7G of reserved capacity across the stack (down from 4.2G), idle actual usage should drop roughly in half, no change to burst capacity for real workloads.

## Scope

Scoped to the swarm-deployed dev stack (`docker-compose-swarm.yaml`), which is what's actually running as `dev`/`dev3` on swarm01/02. Did not touch the local (non-swarm) `docker-compose-dev*.yaml` files or the prod all-in-one image (`docker/supervisord.conf`, deployed from a separate compose repo) — those are candidates for a follow-up once this is validated in dev.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('docker-compose-swarm.yaml'))"` — valid YAML.
- Not yet redeployed/observed live; will watch `docker stats` on swarm01/02 after this rolls out to dev.