### PR TITLE
Update tsparticles 3.0.3 -> 4.3.2

### DIFF
--- a/app/static/config/tsparticles.json
+++ b/app/static/config/tsparticles.json
@@ -1,5 +1,25 @@
 {
+  "name": "Background Mask",
   "autoPlay": true,
+  "clear": false,
+  "defaultThemes": {},
+  "delay": 0,
+  "detectRetina": true,
+  "duration": 0,
+  "fpsLimit": 60,
+  "pauseOnBlur": true,
+  "pauseOnOutsideViewport": true,
+  "smooth": false,
+  "style": {},
+  "zLayers": 100,
+  "fullScreen": {
+    "enable": true,
+    "zIndex": 0
+  },
+  "resize": {
+    "delay": 0.5,
+    "enable": true
+  },
   "backgroundMask": {
     "enable": true,
     "composite": "destination-out",
@@ -14,16 +34,6 @@
       "opacity": 0.8
     }
   },
-  "clear": false,
-  "defaultThemes": {},
-  "delay": 0,
-  "fullScreen": {
-    "enable": true,
-    "zIndex": 0
-  },
-  "detectRetina": true,
-  "duration": 0,
-  "fpsLimit": 60,
   "interactivity": {
     "detectsOn": "window",
     "events": {
@@ -39,24 +49,10 @@
       },
       "onHover": {
         "enable": true,
-        "mode": "bubble",
-        "parallax": {
-          "enable": false,
-          "force": 2,
-          "smooth": 10
-        }
-      },
-      "resize": {
-        "delay": 0.5,
-        "enable": true
+        "mode": "bubble"
       }
     },
     "modes": {
-      "trail": {
-        "delay": 1,
-        "pauseOnStop": false,
-        "quantity": 1
-      },
       "attract": {
         "distance": 200,
         "duration": 0.4,
@@ -96,6 +92,10 @@
           "opacity": 1
         }
       },
+      "parallax": {
+        "force": 2,
+        "smooth": 10
+      },
       "push": {
         "default": true,
         "groups": [],
@@ -125,29 +125,56 @@
         "factor": 3,
         "radius": 200
       },
-      "light": {
-        "area": {
-          "gradient": {
-            "start": {
-              "value": "#ffffff"
-            },
-            "stop": {
-              "value": "#000000"
-            }
-          },
-          "radius": 1000
-        },
-        "shadow": {
-          "color": {
-            "value": "#000000"
-          },
-          "length": 2000
-        }
+      "trail": {
+        "delay": 1,
+        "pauseOnStop": false,
+        "quantity": 1
       }
     }
   },
-  "manualParticles": [],
   "particles": {
+    "groups": {},
+    "reduceDuplicates": false,
+    "paint": {
+      "color": {
+        "value": "#212529",
+        "animation": {
+          "h": {
+            "count": 10,
+            "enable": false,
+            "speed": 1,
+            "decay": 0,
+            "delay": 0,
+            "sync": true,
+            "offset": 0
+          },
+          "s": {
+            "count": 0,
+            "enable": false,
+            "speed": 1,
+            "decay": 0,
+            "delay": 0,
+            "sync": true,
+            "offset": 0
+          },
+          "l": {
+            "count": 0,
+            "enable": false,
+            "speed": 1,
+            "decay": 0,
+            "delay": 0,
+            "sync": true,
+            "offset": 0
+          }
+        }
+      },
+      "fill": {
+        "enable": true
+      },
+      "stroke": {
+        "width": 0
+      }
+    },
     "bounce": {
       "horizontal": {
         "value": 1
@@ -176,57 +203,20 @@
         "retries": 0
       }
     },
-    "color": {
-      "value": "#212529",
-      "animation": {
-        "h": {
-          "count": 10,
-          "enable": false,
-          "speed": 1,
-          "decay": 0,
-          "delay": 0,
-          "sync": true,
-          "offset": 0
-        },
-        "s": {
-          "count": 0,
-          "enable": false,
-          "speed": 1,
-          "decay": 0,
-          "delay": 0,
-          "sync": true,
-          "offset": 0
-        },
-        "l": {
-          "count": 0,
-          "enable": false,
-          "speed": 1,
-          "decay": 0,
-          "delay": 0,
-          "sync": true,
-          "offset": 0
-        }
-      }
-    },
     "effect": {
       "close": true,
-      "fill": true,
       "options": {},
       "type": {}
     },
-    "groups": {},
+    "shape": {
+      "close": true,
+      "options": {},
+      "type": "circle"
+    },
     "move": {
       "angle": {
         "offset": 0,
         "value": 90
-      },
-      "attract": {
-        "distance": 200,
-        "enable": false,
-        "rotate": {
-          "x": 3000,
-          "y": 3000
-        }
       },
       "center": {
         "x": 50,
@@ -268,11 +258,6 @@
         "enable": false
       },
       "straight": false,
-      "trail": {
-        "enable": false,
-        "length": 10,
-        "fill": {}
-      },
       "vibrate": false,
       "warp": false
     },
@@ -302,24 +287,6 @@
         "destroy": "none"
       }
     },
-    "reduceDuplicates": false,
-    "shadow": {
-      "blur": 0,
-      "color": {
-        "value": "#000"
-      },
-      "enable": false,
-      "offset": {
-        "x": 0,
-        "y": 0
-      }
-    },
-    "shape": {
-      "close": true,
-      "fill": true,
-      "options": {},
-      "type": "circle"
-    },
     "size": {
       "value": {
         "min": 10,
@@ -336,9 +303,6 @@
         "startValue": "random",
         "destroy": "none"
       }
-    },
-    "stroke": {
-      "width": 0
     },
     "zIndex": {
       "value": 0,
@@ -389,7 +353,7 @@
       "enable": false
     },
     "twinkle": {
-      "lines": {
+      "links": {
         "enable": true,
         "frequency": 0.05,
         "opacity": 1
@@ -430,22 +394,6 @@
       "direction": "clockwise",
       "path": false
     },
-    "orbit": {
-      "animation": {
-        "count": 0,
-        "enable": false,
-        "speed": 1,
-        "decay": 0,
-        "delay": 0,
-        "sync": false
-      },
-      "enable": false,
-      "opacity": 1,
-      "rotation": {
-        "value": 45
-      },
-      "width": 1
-    },
     "links": {
       "blink": false,
       "color": {
@@ -469,29 +417,6 @@
       },
       "width": 1,
       "warp": false
-    },
-    "repulse": {
-      "value": 0,
-      "enabled": false,
-      "distance": 1,
-      "duration": 1,
-      "factor": 1,
-      "speed": 1
-    }
-  },
-  "pauseOnBlur": true,
-  "pauseOnOutsideViewport": true,
-  "responsive": [],
-  "smooth": false,
-  "style": {},
-  "themes": [],
-  "zLayers": 100,
-  "name": "Background Mask",
-  "motion": {
-    "disable": false,
-    "reduce": {
-      "factor": 10,
-      "value": true
     }
   }
 }

--- a/app/static/js/login.js
+++ b/app/static/js/login.js
@@ -103,16 +103,26 @@ document.addEventListener('DOMContentLoaded', function () {
         '/static/config/tsparticles.json'
     console.debug('tsparticlesConfig:', tsparticlesConfig)
     if (tsparticlesEnabled) {
-        tsParticles
-            .load({
-                id: 'tsparticles',
-                url: tsparticlesConfig,
-            })
-            .then((container) => {
-                console.log('tsparticles loaded:', container)
-            })
+        initParticles(tsparticlesConfig)
     }
 })
+
+/**
+ * Load tsParticles with the shapes/updaters/interactions our config uses.
+ * Since v4 the bundle no longer self-registers on the engine, so loadFull must
+ * run first, and backgroundMask ships as a separate plugin outside the bundle.
+ * @param {string} url tsParticles config URL
+ */
+async function initParticles(url) {
+    try {
+        await loadFull(tsParticles)
+        await loadBackgroundMaskPlugin(tsParticles)
+    } catch (error) {
+        console.warn('tsparticles plugin load failed:', error)
+    }
+    const container = await tsParticles.load({ id: 'tsparticles', url })
+    console.log('tsparticles loaded:', container)
+}
 
 const animateCSS = (selector, animation, prefix = 'animate__') => {
     const name = `${prefix}${animation}`

--- a/app/templates/embed/password.html
+++ b/app/templates/embed/password.html
@@ -60,6 +60,7 @@
     {{ site_settings.tsparticles_enabled|json_script:"tsparticles_enabled" }}
     {{ site_settings.tsparticles_config|json_script:"tsparticles_config" }}
     <script defer src="{% static 'dist/tsparticles/tsparticles.bundle.min.js' %}"></script>
+    <script defer src="{% static 'dist/tsparticles/tsparticles.plugin.background-mask.min.js' %}"></script>
     <script defer src="{% static 'js/login.js' %}"></script>
     <script defer src="{% static 'js/password.js' %}"></script>
 {% endblock %}

--- a/app/templates/login_base.html
+++ b/app/templates/login_base.html
@@ -33,6 +33,7 @@
     {{ site_settings.tsparticles_enabled|json_script:"tsparticles_enabled" }}
     {{ site_settings.tsparticles_config|json_script:"tsparticles_config" }}
     <script defer src="{% static 'dist/tsparticles/tsparticles.bundle.min.js' %}"></script>
+    <script defer src="{% static 'dist/tsparticles/tsparticles.plugin.background-mask.min.js' %}"></script>
     <script defer src="{% static 'js/login.js' %}"></script>
     {% block login_scripts %}{% endblock %}
 {% endblock %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,7 +143,10 @@ gulp.task('swiper', () => {
 
 gulp.task('tsparticles', () => {
     return gulp
-        .src(['node_modules/tsparticles/tsparticles.bundle.min.js'])
+        .src([
+            'node_modules/tsparticles/tsparticles.bundle.min.js',
+            'node_modules/@tsparticles/plugin-background-mask/tsparticles.plugin.background-mask.min.js',
+        ])
         .pipe(gulp.dest('app/static/dist/tsparticles'))
 })
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -169,7 +169,9 @@ http {
 
         location = /internal/hls-auth {
             internal;
-            proxy_pass http://app:9000/api/stream/hls-auth/?name=$hls_name&token=$hls_arg_token&sig=$hls_sig&exp=$hls_exp;
+            resolver 127.0.0.11 valid=30s ipv6=off;
+            set $app_upstream app:9000;
+            proxy_pass http://$app_upstream/api/stream/hls-auth/?name=$hls_name&token=$hls_arg_token&sig=$hls_sig&exp=$hls_exp;
             proxy_pass_request_body off;
             proxy_set_header        Content-Length "";
             # Strip the caller's cookies/Authorization so the upstream view can't
@@ -192,12 +194,10 @@ http {
             return 404;
         }
 
-        # tus resumable uploads: proxy to tusd. Unlike app/redis below, tusd's
-        # startup isn't ordered against nginx, so a static proxy_pass can lose
-        # that race and refuse to start nginx entirely — resolver + variable
-        # upstream defers resolution to request time instead. {{tusd_upstream}}
-        # is templated per image (hostname in compose stacks, literal
-        # 127.0.0.1:8080 in the all-in-one image, see 60-sign-secret.sh).
+        # tus resumable uploads: proxy to tusd. Uses the same resolver +
+        # variable upstream as the app locations (see the note there).
+        # {{tusd_upstream}} is templated per image (hostname in compose stacks,
+        # literal 127.0.0.1:8080 in the all-in-one image, see 60-sign-secret.sh).
         location /tus/ {
             resolver 127.0.0.11 valid=30s ipv6=off;
             set $tusd_upstream {{tusd_upstream}};
@@ -220,7 +220,9 @@ http {
         location  ~ ^/(api/)?upload/?$  {
             client_max_body_size     {{upload_max_size}};
             proxy_request_buffering  off;
-            proxy_pass          http://app:9000;
+            resolver 127.0.0.11 valid=30s ipv6=off;
+            set $app_upstream app:9000;
+            proxy_pass          http://$app_upstream;
             proxy_http_version  1.1;
             proxy_buffering     off;
             proxy_redirect      off;
@@ -230,8 +232,18 @@ http {
             proxy_set_header    X-Forwarded-Host $server_name;
         }
 
+        # A literal hostname in proxy_pass is resolved once at config load and
+        # cached for the worker's lifetime, so nginx pins whatever address the
+        # app had when it started. The app runs migrations before binding :9000,
+        # so nginx routinely loads first and caches a stale/dead address, then
+        # 502s every request until it happens to be restarted — even though the
+        # app is healthy and DNS is correct. resolver + a variable upstream
+        # defers resolution to request time, which also survives app restarts
+        # and IP changes.
         location  /  {
-            proxy_pass          http://app:9000;
+            resolver 127.0.0.11 valid=30s ipv6=off;
+            set $app_upstream app:9000;
+            proxy_pass          http://$app_upstream;
             proxy_http_version  1.1;
             proxy_buffering     off;
             proxy_redirect      off;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",
+        "@tsparticles/plugin-background-mask": "4.3.2",
         "animate.css": "^4.1.1",
         "bootstrap": "^5.3.8",
         "clipboard": "^2.0.11",
@@ -31,7 +32,7 @@
         "qr-code-styling": "^1.9.2",
         "swagger-ui": "^5.32.10",
         "swiper": "^12.1.4",
-        "tsparticles": "3.0.3",
+        "tsparticles": "4.3.2",
         "ua-parser-js": "^2.0.10"
       },
       "devDependencies": {
@@ -1014,11 +1015,33 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/@tsparticles/animation-utils": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/animation-utils/-/animation-utils-4.3.2.tgz",
+      "integrity": "sha512-x4i/F24myZsk/qJEkREbOpzoWJtAbW8cL0Pan0Y5SdmKkG0dyLHw/fTG2uttIA3eeXhPH8JN648pSZMvbNJItw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
     "node_modules/@tsparticles/basic": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-3.9.1.tgz",
-      "integrity": "sha512-ijr2dHMx0IQHqhKW3qA8tfwrR2XYbbWYdaJMQuBo2CkwBVIhZ76U+H20Y492j/NXpd1FUnt2aC0l4CEVGVGdeQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-4.3.2.tgz",
+      "integrity": "sha512-8XTjwZqrxdfT1WUBvhjip1uksdeYBG0k0mr87vebIs7EwCSO//Rau1XYrHE69mSBwYvIqEhLNcwAixHbypG44Q==",
       "funding": [
         {
           "type": "github",
@@ -1035,23 +1058,46 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1",
-        "@tsparticles/move-base": "3.9.1",
-        "@tsparticles/plugin-hex-color": "3.9.1",
-        "@tsparticles/plugin-hsl-color": "3.9.1",
-        "@tsparticles/plugin-rgb-color": "3.9.1",
-        "@tsparticles/shape-circle": "3.9.1",
-        "@tsparticles/updater-color": "3.9.1",
-        "@tsparticles/updater-opacity": "3.9.1",
-        "@tsparticles/updater-out-modes": "3.9.1",
-        "@tsparticles/updater-size": "3.9.1"
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-blend": "4.3.2",
+        "@tsparticles/plugin-hex-color": "4.3.2",
+        "@tsparticles/plugin-hsl-color": "4.3.2",
+        "@tsparticles/plugin-move": "4.3.2",
+        "@tsparticles/plugin-rgb-color": "4.3.2",
+        "@tsparticles/shape-circle": "4.3.2",
+        "@tsparticles/updater-opacity": "4.3.2",
+        "@tsparticles/updater-out-modes": "4.3.2",
+        "@tsparticles/updater-paint": "4.3.2",
+        "@tsparticles/updater-size": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/canvas-utils": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.3.2.tgz",
+      "integrity": "sha512-SN0O1sFhaCH5NfkZK9KawY9dK8YhiDqwPbqv7/Y9/oKmdreXQ2GSkaPOHOGmVDAkl3LYTI8Ip/JfNZaJ1GxDJQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/engine": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-3.9.1.tgz",
-      "integrity": "sha512-DpdgAhWMZ3Eh2gyxik8FXS6BKZ8vyea+Eu5BC4epsahqTGY9V3JGGJcXC6lRJx6cPMAx1A0FaQAojPF3v6rkmQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-4.3.2.tgz",
+      "integrity": "sha512-k4U7uahhxt7bPjEPHu+qrJXjHRysy/QMN+2/KK4d0/V7CElt5/oeR+H9QB95Osy/PtUCCi6EH/LS7k0443qlJA==",
       "funding": [
         {
           "type": "github",
@@ -1070,180 +1116,221 @@
       "license": "MIT"
     },
     "node_modules/@tsparticles/interaction-external-attract": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-3.9.1.tgz",
-      "integrity": "sha512-5AJGmhzM9o4AVFV24WH5vSqMBzOXEOzIdGLIr+QJf4fRh9ZK62snsusv/ozKgs2KteRYQx+L7c5V3TqcDy2upg==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.3.2.tgz",
+      "integrity": "sha512-dMODX9wNrro+E4mjooFSpA9GsGTecqaNzBaSxHY4wUd4Vqlwms3nGfcLs8mr5C6oOz9+i8ADClN30HbcK1n6hw==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-bounce": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-3.9.1.tgz",
-      "integrity": "sha512-bv05+h70UIHOTWeTsTI1AeAmX6R3s8nnY74Ea6p6AbQjERzPYIa0XY19nq/hA7+Nrg+EissP5zgoYYeSphr85A==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.3.2.tgz",
+      "integrity": "sha512-xRa4HT1TZ2T+TdAr3Y6P99hDC3vfvz04QPFr7QaZxnkZDpqeXSzT3VdWa4+PhWnV8s+VzmDI4MWqk5b6dfyq4w==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-bubble": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-3.9.1.tgz",
-      "integrity": "sha512-tbd8ox/1GPl+zr+KyHQVV1bW88GE7OM6i4zql801YIlCDrl9wgTDdDFGIy9X7/cwTvTrCePhrfvdkUamXIribQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.3.2.tgz",
+      "integrity": "sha512-DkFnv+ydwe/ZFsex7S1fmBfaDNFXIZCbBxEmYWylKkiWcm1yTe5A5YzqkEdQZC7tglppf3Jdou9cQXzwoD5HrA==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-connect": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-3.9.1.tgz",
-      "integrity": "sha512-sq8YfUNsIORjXHzzW7/AJQtfi/qDqLnYG2qOSE1WOsog39MD30RzmiOloejOkfNeUdcGUcfsDgpUuL3UhzFUOA==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.3.2.tgz",
+      "integrity": "sha512-hZI01JrXCJLVO4l8jq5nB/6U+ghE7SjOoqbUqR8sM/PiNA6jQupibweyhvK8R/4Rh+soAYZHZ1uBFxXwpXOb5A==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-destroy": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.3.2.tgz",
+      "integrity": "sha512-HNb4zbZQwMIurFGT/TeyJ2NVlIrBRgVuc93mRIWIA1vOdFZMEkkE1mgP55sOii/vASp/UAB+dXaaJP37gaC46w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-drag": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-drag/-/interaction-external-drag-4.3.2.tgz",
+      "integrity": "sha512-vIxKHosmGjSDV7JVwJ3lpGjzJGFRNtgzEtIXrVh/QtZv0kSEmsj1+c5Xw43Oxz1xO6eO68DYFgPlixf4egxU6Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-grab": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-3.9.1.tgz",
-      "integrity": "sha512-QwXza+sMMWDaMiFxd8y2tJwUK6c+nNw554+/9+tEZeTTk2fCbB0IJ7p/TH6ZGWDL0vo2muK54Njv2fEey191ow==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.3.2.tgz",
+      "integrity": "sha512-WITZJ4u36yPEcnVljpfWhMc8aJn07Zz8Eq7u5umERBTKF0QdLrMWseM3HgSv7AOV04fp86CDciVLOa2Ivdwcrw==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-parallax": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.3.2.tgz",
+      "integrity": "sha512-sdP7OI7pMbKfvI819M9Ini3Lm8/OR3Lt3jXWb7gP8bDUxZ0zbWa5gmkZjWwyW8bFzBMssjSY1J1GhkZzTMv6Yg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-pause": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-3.9.1.tgz",
-      "integrity": "sha512-Gzv4/FeNir0U/tVM9zQCqV1k+IAgaFjDU3T30M1AeAsNGh/rCITV2wnT7TOGFkbcla27m4Yxa+Fuab8+8pzm+g==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.3.2.tgz",
+      "integrity": "sha512-nuIoXWAFb1wVNk29iiGJHjN6XaPlUJjsLsF1Tl9QhKAlXvrXk08zZsU7QVJ4bzMhyQ94IZdzNAVPd4cvOhVrHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-push": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-3.9.1.tgz",
-      "integrity": "sha512-GvnWF9Qy4YkZdx+WJL2iy9IcgLvzOIu3K7aLYJFsQPaxT8d9TF8WlpoMlWKnJID6H5q4JqQuMRKRyWH8aAKyQw==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.3.2.tgz",
+      "integrity": "sha512-2buFHr/73pdHMXaFPUFjdY0STWysvEGJpSYSAwmvt58WHVbM1z2XwBMpozQwRe15UNDw3H5ddeiVkIKuqwjZlQ==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-remove": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-3.9.1.tgz",
-      "integrity": "sha512-yPThm4UDWejDOWW5Qc8KnnS2EfSo5VFcJUQDWc1+Wcj17xe7vdSoiwwOORM0PmNBzdDpSKQrte/gUnoqaUMwOA==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.3.2.tgz",
+      "integrity": "sha512-iJW2VuguF+cIUEHnrdFcVWTZMJnZ7j0q74Jut3FQy4XyGTzD2P8UCswbfpnZHQssGIPMupp7bHNIXOOchLTrtw==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-repulse": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-3.9.1.tgz",
-      "integrity": "sha512-/LBppXkrMdvLHlEKWC7IykFhzrz+9nebT2fwSSFXK4plEBxDlIwnkDxd3FbVOAbnBvx4+L8+fbrEx+RvC8diAw==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.3.2.tgz",
+      "integrity": "sha512-o0RyOjQROCqpJzjaMcNFew9afvJdKJB94E5XYoJCYK6Pwhp0BFMariXe91/yTdguIYrjUwJMQ5bvyBejP4Ygzw==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-slow": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-3.9.1.tgz",
-      "integrity": "sha512-1ZYIR/udBwA9MdSCfgADsbDXKSFS0FMWuPWz7bm79g3sUxcYkihn+/hDhc6GXvNNR46V1ocJjrj0u6pAynS1KQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.3.2.tgz",
+      "integrity": "sha512-wMdbZ6xD0QQJ1W077iJvHyCJ2kKHpE4+/xu0B7ffTHesn6vYv4K+CWUVvBTwVC5sJVq4Q2Av974qOfxIhMY7ZQ==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-external-trail": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-3.9.1.tgz",
-      "integrity": "sha512-Au0v2oiqfKTemI/4bzjD4dUXzIngB5Q2T4nJcMCYpP24uZfwZh5xTjUMH7gyJyyaRTdMl9IJrp8ySjyYbLfeGg==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-4.3.2.tgz",
+      "integrity": "sha512-lpmkLRtUF+00dGjQnwXyotR5R5XHipQxAk/FrOsVRNNi2+IGazJE7+LmJHDJdtI6GoFwfC+uriwTqS67MlSWfA==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-particles-attract": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-3.9.1.tgz",
-      "integrity": "sha512-CYYYowJuGwRLUixQcSU/48PTKM8fCUYThe0hXwQ+yRMLAn053VHzL7NNZzKqEIeEyt5oJoy9KcvubjKWbzMBLQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.3.2.tgz",
+      "integrity": "sha512-X2GUryt0e5tkeQmIAt7QDqiq3OtNXE72QrM2a+T8E3T0Cvq9/UqrOtlCm6VKlel9OV2NAUi3BH84oCvOcqfYFg==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-particles-collisions": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-3.9.1.tgz",
-      "integrity": "sha512-ggGyjW/3v1yxvYW1IF1EMT15M6w31y5zfNNUPkqd/IXRNPYvm0Z0ayhp+FKmz70M5p0UxxPIQHTvAv9Jqnuj8w==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.3.2.tgz",
+      "integrity": "sha512-dLBgNXAdRJN2bFTYPEK3lvSeJFWOT1gv22aGOBatPPxLZ+mH5w3oH8LE2noa7tBpiyG4tVEzMzZUIdp57SemPg==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/interaction-particles-links": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-3.9.1.tgz",
-      "integrity": "sha512-MsLbMjy1vY5M5/hu/oa5OSRZAUz49H3+9EBMTIOThiX+a+vpl3sxc9AqNd9gMsPbM4WJlub8T6VBZdyvzez1Vg==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.3.2.tgz",
+      "integrity": "sha512-h0bZcpj2tFItovtzCMyHCqu2Fhz+/N9oXQctvmD9sf7C7eya26ZsISEgPqqFIAvdwLYhmQTk5fns4d/6Y7yRWg==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
-      }
-    },
-    "node_modules/@tsparticles/move-base": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/move-base/-/move-base-3.9.1.tgz",
-      "integrity": "sha512-X4huBS27d8srpxwOxliWPUt+NtCwY+8q/cx1DvQxyqmTA8VFCGpcHNwtqiN+9JicgzOvSuaORVqUgwlsc7h4pQ==",
-      "deprecated": "this package was deprecated in tsparticles v4, replaced by @tsparticles/plugin-move",
-      "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
-      }
-    },
-    "node_modules/@tsparticles/move-parallax": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/move-parallax/-/move-parallax-3.9.1.tgz",
-      "integrity": "sha512-whlOR0bVeyh6J/hvxf/QM3DqvNnITMiAQ0kro6saqSDItAVqg4pYxBfEsSOKq7EhjxNvfhhqR+pFMhp06zoCVA==",
-      "deprecated": "this package was deprecated in tsparticles v4, replaced by @tsparticles/interaction-external-parallax",
-      "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
       }
     },
     "node_modules/@tsparticles/plugin-absorbers": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-3.9.1.tgz",
-      "integrity": "sha512-q9SQllpbPPgw1+euxHPYCFawOVUazQkkwnleiIgpYSiimlCyjIdwGnFPSNe1Sypzqmr2h6oOyX2vkK5ZVNEu8A==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-4.3.2.tgz",
+      "integrity": "sha512-g1CeYTQi7EvBKECHr/3uo5YKS9+YfefD2l75rwzdFEwALCEFOOjTINBrwwx7UWjYSn1Hpe0oIRMVQ02wXFziFw==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      },
+      "peerDependenciesMeta": {
+        "@tsparticles/plugin-interactivity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tsparticles/plugin-background-mask": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-background-mask/-/plugin-background-mask-4.3.2.tgz",
+      "integrity": "sha512-KrmxuQw34m8UjYsd2lkHrJ6ugrvCSmkyRTVQcHgYcfB8bG/At/43HMS3WzmgArqG2r8hRQeJiDKIm6Z6PrDWdQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-blend": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-blend/-/plugin-blend-4.3.2.tgz",
+      "integrity": "sha512-5iUDwzvcOtiaFvsbL3y+UzneGrlNwITB8HlNCfjp675wrg9xh7ILHa3/ZYHii1qC8gkKNva0w2N+wET9n+XWBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/plugin-easing-quad": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-3.9.1.tgz",
-      "integrity": "sha512-C2UJOca5MTDXKUTBXj30Kiqr5UyID+xrY/LxicVWWZPczQW2bBxbIbfq9ULvzGDwBTxE2rdvIB8YFKmDYO45qw==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.3.2.tgz",
+      "integrity": "sha512-yrh6KSD+UEY8aW3hnfzVL84neUwCZ1ZqU/cj5jTHDQ7zFbYu8QA6zhR30kYHI645VmCaMjp+zuZ2ii6rwXsVIQ==",
       "funding": [
         {
           "type": "github",
@@ -1259,23 +1346,29 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/plugin-emitters": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-3.9.1.tgz",
-      "integrity": "sha512-h7opR8SoFWBmVHceDLJUerLENaPfkJSh2zQYvzmLj2L+V3VLS1QDgty+4QZVeZfqNROmgQw2eLFA5El1E0sqqw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-4.3.2.tgz",
+      "integrity": "sha512-wKUw3lkGwUOBNtRC2XuzVLwh6Nur112GG9T+O43quio+J5YjOMGEsfeFaWL3R7kgrj0d+VvQlJESsyZeccgQlg==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      },
+      "peerDependenciesMeta": {
+        "@tsparticles/plugin-interactivity": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tsparticles/plugin-emitters-shape-circle": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-3.9.1.tgz",
-      "integrity": "sha512-z+9MsAPWr++sNz6N6303rRDjusW0BIPhHY51E5eXGDcRdOqrESDs6y99AJ/6Kdb/PpibCIYjFY9jVi2JJADPRA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-4.3.2.tgz",
+      "integrity": "sha512-MEZcQ8sMx9nHPIlO5+pC6HXFbxtL54Kq9OrVNxsvsKCf03v2Rnf63jlqXeWkxx0XYUNpYSumc39IzQuaouyXPw==",
       "funding": [
         {
           "type": "github",
@@ -1291,15 +1384,15 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1",
-        "@tsparticles/plugin-emitters": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-emitters": "4.3.2"
       }
     },
     "node_modules/@tsparticles/plugin-emitters-shape-square": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-3.9.1.tgz",
-      "integrity": "sha512-dhA1c7FKs19B8lgTf25OTA3JoptNA+rjorsqCFuY1BZDI8g9E8DNqikUge14/W7nZN96+98hY+ghxSl4K2YsgA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-4.3.2.tgz",
+      "integrity": "sha512-sXYep9YCfwsAC/efjUD3jnU0QJ0R0dOcU6oKXLWieMrAmHoa/mP7aN/ZEUntkta8cmi95bswUc8rshBez3DplQ==",
       "funding": [
         {
           "type": "github",
@@ -1315,15 +1408,15 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1",
-        "@tsparticles/plugin-emitters": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-emitters": "4.3.2"
       }
     },
     "node_modules/@tsparticles/plugin-hex-color": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-3.9.1.tgz",
-      "integrity": "sha512-vZgZ12AjUicJvk7AX4K2eAmKEQX/D1VEjEPFhyjbgI7A65eX72M465vVKIgNA6QArLZ1DLs7Z787LOE6GOBWsg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.3.2.tgz",
+      "integrity": "sha512-uRNSHx/d3hByVYAwPHKKoKxy7s0QujhNUpsgDuL92JODKCjCFm8SudbkW3STSXVznhY5bCcu4iAF+7zKVgVXCg==",
       "funding": [
         {
           "type": "github",
@@ -1339,15 +1432,14 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/plugin-hsl-color": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-3.9.1.tgz",
-      "integrity": "sha512-jJd1iGgRwX6eeNjc1zUXiJivaqC5UE+SC2A3/NtHwwoQrkfxGWmRHOsVyLnOBRcCPgBp/FpdDe6DIDjCMO715w==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.3.2.tgz",
+      "integrity": "sha512-kvRux8WnToyy9Dr8ROYvNDnE0HPW5h7x3wBROOghlazGYvYPO4nJBFvcmvvISRF6Ghsm9bzY255Qun2vACv2tA==",
       "funding": [
         {
           "type": "github",
@@ -1363,15 +1455,32 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-interactivity": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.3.2.tgz",
+      "integrity": "sha512-GIOiyrSn2Zf+cWxLPeUeYG4qjSeGzDcocbSiLcAaPPjZ5J+D0LOBsrrb6qvqMvUj0qCkjKF4cIf7OgznhkdZkw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-move": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.3.2.tgz",
+      "integrity": "sha512-8nSDxWhxVWl9JzX/fSZwz5ZVzEMMFJLF3vizjfag2zE+jc4Nidfs9ZOPrD4yxpKSfZiv1ZwJpoOhT2ch4sVTug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/plugin-rgb-color": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-3.9.1.tgz",
-      "integrity": "sha512-SBxk7f1KBfXeTnnklbE2Hx4jBgh6I6HOtxb+Os1gTp0oaghZOkWcCD2dP4QbUu7fVNCMOcApPoMNC8RTFcy9wQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.3.2.tgz",
+      "integrity": "sha512-/4xZBlEWqqG7VscJzC2VimA62fxDboe4XO1+m8LeM2ytxrhEpNk14TeBJt+zCc8jBkFjpKOdmTZ0VYyuK4FtDQ==",
       "funding": [
         {
           "type": "github",
@@ -1387,95 +1496,92 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-circle": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-3.9.1.tgz",
-      "integrity": "sha512-DqZFLjbuhVn99WJ+A9ajz9YON72RtCcvubzq6qfjFmtwAK7frvQeb6iDTp6Ze9FUipluxVZWVRG4vWTxi2B+/g==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.3.2.tgz",
+      "integrity": "sha512-IOStpEafsK9vIZsXtrO1zpqF3pW5ydstD8db4omioAnoYFfKwbgyfkQz9l4pDnJy8636RbnQNVbYGlyxKuJ0cw==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-emoji": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-3.9.1.tgz",
-      "integrity": "sha512-ifvY63usuT+hipgVHb8gelBHSeF6ryPnMxAAEC1RGHhhXfpSRWMtE6ybr+pSsYU52M3G9+TF84v91pSwNrb9ZQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.3.2.tgz",
+      "integrity": "sha512-et8OLZpt1fJsBBEhb0NHp++MeMF3Q3VZq1JMzdaI6i1rCm8h8yfEbi96Izz+e1OFYKpY/qZfyVxrLnW33VYFJg==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-image": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-3.9.1.tgz",
-      "integrity": "sha512-fCA5eme8VF3oX8yNVUA0l2SLDKuiZObkijb0z3Ky0qj1HUEVlAuEMhhNDNB9E2iELTrWEix9z7BFMePp2CC7AA==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.3.2.tgz",
+      "integrity": "sha512-EtKkH7DMI+2rcF9n5VCJWKcyI/jX+B/OfucM/9MThG5qApqLBzfZvxRQRFG2agZKIHByGmXtfZyou4y2XPuq9g==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-line": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-3.9.1.tgz",
-      "integrity": "sha512-wT8NSp0N9HURyV05f371cHKcNTNqr0/cwUu6WhBzbshkYGy1KZUP9CpRIh5FCrBpTev34mEQfOXDycgfG0KiLQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.3.2.tgz",
+      "integrity": "sha512-ph8q+9vx8BxYb1JToPde6v0Vejfg+hPGEWYhD5J5orrLcxqjmGimbRd+ycFV+fgHcmFDzfzlVUtiR7U+F3mgNg==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-polygon": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-3.9.1.tgz",
-      "integrity": "sha512-dA77PgZdoLwxnliH6XQM/zF0r4jhT01pw5y7XTeTqws++hg4rTLV9255k6R6eUqKq0FPSW1/WBsBIl7q/MmrqQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.3.2.tgz",
+      "integrity": "sha512-ebpHYQlk0khRXFtG1WWQIQSIedb23OEICWuhTAmh87lVkFkNeU5synyS6UqxSOXda098BiRnO++P69Sfq12E5w==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-square": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-3.9.1.tgz",
-      "integrity": "sha512-DKGkDnRyZrAm7T2ipqNezJahSWs6xd9O5LQLe5vjrYm1qGwrFxJiQaAdlb00UNrexz1/SA7bEoIg4XKaFa7qhQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.3.2.tgz",
+      "integrity": "sha512-U3q5TdvDclXSAM6ott4evZaWt00o+mEmO0RUsIGZR4W0DdaaZTa0zmeitQnM/wJnkwpXUqVWF3H88FS1MOy9ag==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-star": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-3.9.1.tgz",
-      "integrity": "sha512-kdMJpi8cdeb6vGrZVSxTG0JIjCwIenggqk0EYeKAwtOGZFBgL7eHhF2F6uu1oq8cJAbXPujEoabnLsz6mW8XaA==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.3.2.tgz",
+      "integrity": "sha512-i8AquyuaJ3GH3qsWIepVbsdxCM0Tl0ZFSmJni8AC+ly2Py7+Ig/uJpxM9oC5YkNdcAU6vosMgAS3xUobVQDvsg==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/shape-text": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-3.9.1.tgz",
-      "integrity": "sha512-oNsLHI0lGkIXoUw3W598iwd7dtoHCDrwpwJRGnQzgfk6T5a9dCpSD5vDeQN89lr3BUbVui4lhxq+/TyC64oAqA==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-4.3.2.tgz",
+      "integrity": "sha512-1r57n5WYWIToasVVPHfpLfY5RcuY1iP+Aa2fq8fWmtJklHXUKH4j3lMSJjTsejm/ieYANlZGPmPaX1bTO6INXw==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/slim": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-3.9.1.tgz",
-      "integrity": "sha512-CL5cDmADU7sDjRli0So+hY61VMbdroqbArmR9Av+c1Fisa5ytr6QD7Jv62iwU2S6rvgicEe9OyRmSy5GIefwZw==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-4.3.2.tgz",
+      "integrity": "sha512-VDCC1xod/Ak9Pn+OD/5AT6y3ccPR3n+EHQBZJKin81yYE/+POfNZ+tDSg/cMmrNBW6MFobKVJpp2kO0AoYFvrw==",
       "funding": [
         {
           "type": "github",
@@ -1492,152 +1598,145 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/basic": "3.9.1",
-        "@tsparticles/engine": "3.9.1",
-        "@tsparticles/interaction-external-attract": "3.9.1",
-        "@tsparticles/interaction-external-bounce": "3.9.1",
-        "@tsparticles/interaction-external-bubble": "3.9.1",
-        "@tsparticles/interaction-external-connect": "3.9.1",
-        "@tsparticles/interaction-external-grab": "3.9.1",
-        "@tsparticles/interaction-external-pause": "3.9.1",
-        "@tsparticles/interaction-external-push": "3.9.1",
-        "@tsparticles/interaction-external-remove": "3.9.1",
-        "@tsparticles/interaction-external-repulse": "3.9.1",
-        "@tsparticles/interaction-external-slow": "3.9.1",
-        "@tsparticles/interaction-particles-attract": "3.9.1",
-        "@tsparticles/interaction-particles-collisions": "3.9.1",
-        "@tsparticles/interaction-particles-links": "3.9.1",
-        "@tsparticles/move-parallax": "3.9.1",
-        "@tsparticles/plugin-easing-quad": "3.9.1",
-        "@tsparticles/shape-emoji": "3.9.1",
-        "@tsparticles/shape-image": "3.9.1",
-        "@tsparticles/shape-line": "3.9.1",
-        "@tsparticles/shape-polygon": "3.9.1",
-        "@tsparticles/shape-square": "3.9.1",
-        "@tsparticles/shape-star": "3.9.1",
-        "@tsparticles/updater-life": "3.9.1",
-        "@tsparticles/updater-rotate": "3.9.1",
-        "@tsparticles/updater-stroke-color": "3.9.1"
-      }
-    },
-    "node_modules/@tsparticles/updater-color": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-color/-/updater-color-3.9.1.tgz",
-      "integrity": "sha512-XGWdscrgEMA8L5E7exsE0f8/2zHKIqnTrZymcyuFBw2DCB6BIV+5z6qaNStpxrhq3DbIxxhqqcybqeOo7+Alpg==",
-      "deprecated": "this package was deprecated in tsparticles v4, replaced by @tsparticles/updater-paint",
-      "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/basic": "4.3.2",
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/interaction-external-attract": "4.3.2",
+        "@tsparticles/interaction-external-bounce": "4.3.2",
+        "@tsparticles/interaction-external-bubble": "4.3.2",
+        "@tsparticles/interaction-external-connect": "4.3.2",
+        "@tsparticles/interaction-external-destroy": "4.3.2",
+        "@tsparticles/interaction-external-grab": "4.3.2",
+        "@tsparticles/interaction-external-parallax": "4.3.2",
+        "@tsparticles/interaction-external-pause": "4.3.2",
+        "@tsparticles/interaction-external-push": "4.3.2",
+        "@tsparticles/interaction-external-remove": "4.3.2",
+        "@tsparticles/interaction-external-repulse": "4.3.2",
+        "@tsparticles/interaction-external-slow": "4.3.2",
+        "@tsparticles/interaction-particles-attract": "4.3.2",
+        "@tsparticles/interaction-particles-collisions": "4.3.2",
+        "@tsparticles/interaction-particles-links": "4.3.2",
+        "@tsparticles/plugin-easing-quad": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2",
+        "@tsparticles/shape-emoji": "4.3.2",
+        "@tsparticles/shape-image": "4.3.2",
+        "@tsparticles/shape-line": "4.3.2",
+        "@tsparticles/shape-polygon": "4.3.2",
+        "@tsparticles/shape-square": "4.3.2",
+        "@tsparticles/shape-star": "4.3.2",
+        "@tsparticles/updater-life": "4.3.2",
+        "@tsparticles/updater-paint": "4.3.2",
+        "@tsparticles/updater-rotate": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-destroy": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-3.9.1.tgz",
-      "integrity": "sha512-MjMzEhZwCQIbxO6ZRM0eXsHVwmlXuUqwC43WCPZCpjhK3AJrMu3KR4xsJieFTWIbVNguAvbgoTB10FfJOUU5VA==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-4.3.2.tgz",
+      "integrity": "sha512-aTkmklndTYdUWwCTswn2gUxfersRQMrZa++pXPc9EgamoTnsTAcWGNb4x89sSviwjSt5Oyw78LadZZZfRvX2Ew==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-life": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-3.9.1.tgz",
-      "integrity": "sha512-Oi8aF2RIwMMsjssUkCB6t3PRpENHjdZf6cX92WNfAuqXtQphr3OMAkYFJFWkvyPFK22AVy3p/cFt6KE5zXxwAA==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-4.3.2.tgz",
+      "integrity": "sha512-RL3803nFKsCsGQavLSZyEiFWhto9R4+QQ/tsqt8PNmHOC7nmI96ZVGVXDknaSuCM4OwuwrDawIdrZUv6OSEFSQ==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-opacity": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-3.9.1.tgz",
-      "integrity": "sha512-w778LQuRZJ+IoWzeRdrGykPYSSaTeWfBvLZ2XwYEkh/Ss961InOxZKIpcS6i5Kp/Zfw0fS1ZAuqeHwuj///Osw==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.3.2.tgz",
+      "integrity": "sha512-Mw4WN/E+ZQQkL683/oyLkebDMpSpbqDRgx2GhMqWOQNTDby5RYG6wSrq0cGtg0aLZmkoYDYLz5Al7wjPfX0/LA==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/animation-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-out-modes": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-3.9.1.tgz",
-      "integrity": "sha512-cKQEkAwbru+hhKF+GTsfbOvuBbx2DSB25CxOdhtW2wRvDBoCnngNdLw91rs+0Cex4tgEeibkebrIKFDDE6kELg==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.3.2.tgz",
+      "integrity": "sha512-lGiYbrFGaAmBakCrEf3Xq5W+LzDkvfINav0MGxCe/acf7u3yvjOUkVH0Co1zc/ju43nU5U2ZO88Anqk4xKtoPA==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/updater-paint": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.3.2.tgz",
+      "integrity": "sha512-cp020EtLL0zjsILL1w07r8n8wmwzziuHwtQ0GqGaGq+SikrdoK6yT/sXbyAylJqDypNaloVy3NZMq4wNQtxLOg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-roll": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-3.9.1.tgz",
-      "integrity": "sha512-zl4JeM3gUBJ0uttmIsond3lrZ3f3AkItFeS0Lhj/7jiCKfUoRyyOMrcBk8R1AhW7lI+7ko1iBs3jhO0jnxz9vg==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-4.3.2.tgz",
+      "integrity": "sha512-5PG/uZx8EcwKV2WeyZ9ww4DyE/HjUcuF4loIAJSt2qNP66pwzMnZ0LqD+YOCRWhhm+/ESry3JNHaAWmJY6yp/A==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-rotate": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-3.9.1.tgz",
-      "integrity": "sha512-9BfKaGfp28JN82MF2qs6Ae/lJr9EColMfMTHqSKljblwbpVDHte4umuwKl3VjbRt87WD9MGtla66NTUYl+WxuQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-4.3.2.tgz",
+      "integrity": "sha512-vDp7sg+FQQ9NRY6Nh2Joccd5oqmv6W1Y0L56AWrxjc6wk29IRuVeRo1QuoqRLzqq/xLJBhsbkyKXZG0wiE8Blg==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/animation-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-size": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-3.9.1.tgz",
-      "integrity": "sha512-3NSVs0O2ApNKZXfd+y/zNhTXSFeG1Pw4peI8e6z/q5+XLbmue9oiEwoPy/tQLaark3oNj3JU7Q903ZijPyXSzw==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.3.2.tgz",
+      "integrity": "sha512-U7YtYqH0MvALOS4Nr33soOFJ63n8qS9Xujl9BcNZnbmRBf4xgOnTC1TztMvGO19GANTBwq4QKsKQiwFlwAk4qw==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
-      }
-    },
-    "node_modules/@tsparticles/updater-stroke-color": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-stroke-color/-/updater-stroke-color-3.9.1.tgz",
-      "integrity": "sha512-3x14+C2is9pZYTg9T2TiA/aM1YMq4wLdYaZDcHm3qO30DZu5oeQq0rm/6w+QOGKYY1Z3Htg9rlSUZkhTHn7eDA==",
-      "deprecated": "this package was deprecated in tsparticles v4, replaced by @tsparticles/updater-paint",
-      "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/animation-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-tilt": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-3.9.1.tgz",
-      "integrity": "sha512-PB2yaoyXRmSk4iIVgjtRrzOxXMK9mjeAQHIJGtT4faq46Z8cbIIEFgjTwqrUV8qOrNg/h4sm5NE/s0qsTYjp1Q==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-4.3.2.tgz",
+      "integrity": "sha512-iPI0Fc86Nyuxvm0Dx+aPOZ6d7fDZ4SNk+TulCbMQz9Zf5/p6nYB9CDjAuvmTDCLqzZCMUtrwbbzJfLKR7R5Gog==",
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+        "@tsparticles/animation-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-twinkle": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-3.9.1.tgz",
-      "integrity": "sha512-xgTcYr6LmP44IPIBeQmEExN2Y5Nfl3ikmC08eOh5nZy/ta6ORP+JTsprrnfuv/O2DwTyoqFLkZ16hZfkdc1yOQ==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-4.3.2.tgz",
+      "integrity": "sha512-zjk9sStqw4fZMOa9IzmBILNG3bavTMH2vaaVzNjj6s11lstoQVch6UjQKU0T7E8ugrtdKWptIcwvBajFeNpeDQ==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tsparticles/updater-wobble": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-3.9.1.tgz",
-      "integrity": "sha512-c99Ogy9q4QWO+zsDXol0UnpUwZiY2UucFb8ltuDv9AlbGUeprygoub8jhgT5pEDv+GdzWOJGSgq7rfgv9cHBrg==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-4.3.2.tgz",
+      "integrity": "sha512-nRKKFkjUgFoQG+WpDASlqj4hUPwafgHb9pLjuqAN7ko0udvajspF01nuXFgDznEIVcVU9pXfq9KfQPiU+xyjiQ==",
       "license": "MIT",
-      "dependencies": {
-        "@tsparticles/engine": "3.9.1"
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@types/estree": {
@@ -6067,10 +6166,9 @@
       "license": "0BSD"
     },
     "node_modules/tsparticles": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-3.0.3.tgz",
-      "integrity": "sha512-chClgQd4ePebjMk0UtK91ELPsOCcA7pBvDrzb54Yyzy66S5Ksa8oEhuepCfVAREyrAzn0YVuEue07SXvWXS88Q==",
-      "deprecated": "Please update to version 4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-4.3.2.tgz",
+      "integrity": "sha512-4seFHUmXUx7vChyA03VArYXkT1ltV6zWq047j7VEtrSZpY+6sh9+bZ8wrTYjjoTrYqZSNW8pHbavqGH9rq8Z7A==",
       "funding": [
         {
           "type": "github",
@@ -6087,19 +6185,20 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@tsparticles/engine": "^3.0.3",
-        "@tsparticles/interaction-external-trail": "^3.0.3",
-        "@tsparticles/plugin-absorbers": "^3.0.3",
-        "@tsparticles/plugin-emitters": "^3.0.3",
-        "@tsparticles/plugin-emitters-shape-circle": "^3.0.3",
-        "@tsparticles/plugin-emitters-shape-square": "^3.0.3",
-        "@tsparticles/shape-text": "^3.0.3",
-        "@tsparticles/slim": "^3.0.3",
-        "@tsparticles/updater-destroy": "^3.0.3",
-        "@tsparticles/updater-roll": "^3.0.3",
-        "@tsparticles/updater-tilt": "^3.0.3",
-        "@tsparticles/updater-twinkle": "^3.0.3",
-        "@tsparticles/updater-wobble": "^3.0.3"
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/interaction-external-drag": "4.3.2",
+        "@tsparticles/interaction-external-trail": "4.3.2",
+        "@tsparticles/plugin-absorbers": "4.3.2",
+        "@tsparticles/plugin-emitters": "4.3.2",
+        "@tsparticles/plugin-emitters-shape-circle": "4.3.2",
+        "@tsparticles/plugin-emitters-shape-square": "4.3.2",
+        "@tsparticles/shape-text": "4.3.2",
+        "@tsparticles/slim": "4.3.2",
+        "@tsparticles/updater-destroy": "4.3.2",
+        "@tsparticles/updater-roll": "4.3.2",
+        "@tsparticles/updater-tilt": "4.3.2",
+        "@tsparticles/updater-twinkle": "4.3.2",
+        "@tsparticles/updater-wobble": "4.3.2"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",
+    "@tsparticles/plugin-background-mask": "4.3.2",
     "animate.css": "^4.1.1",
     "bootstrap": "^5.3.8",
     "clipboard": "^2.0.11",
@@ -46,7 +47,7 @@
     "qr-code-styling": "^1.9.2",
     "swagger-ui": "^5.32.10",
     "swiper": "^12.1.4",
-    "tsparticles": "3.0.3",
+    "tsparticles": "4.3.2",
     "ua-parser-js": "^2.0.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates `tsparticles` from **3.0.3 → 4.3.2** while preserving the exact "Background Mask" look on the login / unlock screens.

## Why previous attempts lost the particle set

Two v4 breaking changes, both silent — no console error, just an empty or plain background:

1. **The bundle no longer self-registers.** In v3, loading `tsparticles.bundle.min.js` installed every shape/updater/interaction onto the engine. In v4 the bundle exports `loadFull(engine)`, which must be awaited before `tsParticles.load()`. Without it, `particles.color`, `opacity`, `size`, `links`, `twinkle` and the whole `interactivity` block are silently dropped at parse time.
2. **`backgroundMask` was removed from the full bundle.** It now ships as its own package, `@tsparticles/plugin-background-mask`, registered via `loadBackgroundMaskPlugin(engine)`. That option is the entire visual — particles cut holes through a black `destination-out` cover — so losing it flattens the effect completely.

## Config migration (`app/static/config/tsparticles.json`)

Verified by parsing the config in a real browser under both versions and diffing every key against `container.actualOptions`:

| v3 | v4 |
| --- | --- |
| `particles.color` | `particles.paint.color` |
| `particles.stroke` | `particles.paint.stroke` |
| `particles.shape.fill` (bool) | `particles.paint.fill.enable` |
| `interactivity.events.resize` | top-level `resize` |
| `interactivity.events.onHover.parallax` | `interactivity.modes.parallax` (`force`/`smooth` only) |
| `particles.twinkle.lines` | `particles.twinkle.links` |
| `particles.shadow`, `move.attract`, `move.trail` | removed |

Also dropped keys that v4 has no loader for and that were already dead in v3 (`manualParticles`, `responsive`, `themes`, `motion`, `modes.light`, `particles.orbit`, `particles.repulse`) — confirmed ignored under 3.0.3 too, so this is not a behaviour change.

Every remaining key in the new config now round-trips through v4's parser with zero unrecognised paths.

## Testing

- Rendered v3+old-config and v4+new-config side by side in Chrome — same mask cut-out, particle sizes, white links, colors.
- Loaded the real `/oauth/` login page against a local Django instance: engine reports `4.3.2`, 92 particles, `backgroundMask: true/destination-out`, `paint.color: #212529`, `onHover: bubble`; console clean, no warnings.
- Verified hover-bubble interaction enlarges particles near the cursor.
- Full suite: `Ran 225 tests` — 1 failure + 1 error, byte-identical to the same run on clean master (`test_files`, `test_pre_create_session_cookie_with_origin`), both pre-existing.
- `ruff` / `black` / `isort` / `eslint` / `prettier` clean.

## Deployment note

`dist/` is gitignored, so the new `tsparticles.plugin.background-mask.min.js` is produced by the existing `npm run postinstall` → gulp step; no new build wiring beyond the added `gulp.src` entry.

Existing installs keep the default `tsparticles_config` of `/static/config/tsparticles.json` and pick this up automatically. Anyone who pointed that setting at a **custom v3 config** will need the same migration above — v4 ignores the stale keys rather than erroring, so their particles will render with defaults for whatever moved.
