### PR TITLE
Update swagger-ui and highlight.js to clear 4 npm security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -321,13 +321,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.3.tgz",
-      "integrity": "sha512-Nfi/0vy+cIHClX7raXamtHnCMBbwI1PEg+yroIzyy8LcCH7zcS0Xi4ARG3CkDQswOnWO2gLDAUAFjDvkQWdZ+A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.12.0.tgz",
+      "integrity": "sha512-C4Px0M/hNIBf2jFphrHlKe8rN5OuUaxNb3FNandzM8++Uyp9TKjdt0+FI6+sX4s8u3axvQ4c4jrjb0LW7r2jPA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -335,14 +335,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.3.tgz",
-      "integrity": "sha512-21/PXEqCzsWkiwKWHt0TPJE7GUtog3BhMlvYLUEPbteXOrk+PNazbjYDPl4zfZGRLaoGhTqpFBY5pXafdzaHWQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.12.0.tgz",
+      "integrity": "sha512-HXiJ6c7R/Sfpj1nz8Tgzy6jvaKE333b3FA4XTuKrwne/fgGq+ITksp6SaDMp7F/FbvP8iik2OFT9wJ3BRw1wjw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
@@ -352,37 +352,52 @@
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.3.tgz",
-      "integrity": "sha512-Z4mIDyZUF2kDFHBzKsxkYSaHpGSvGDc7gAkdzLKxcQk4849iCUXxs0PpQLxZxfYcmUSwkw7AZmIP/OKGpsR8JA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.12.0.tgz",
+      "integrity": "sha512-mdQbyeolFyhyJiVchAJlfOUYntD4p10ORtpVRTLw0vFfqQZtDfr+uMVgiB/kmmyTZ27PoJPR51RDqaXB88aq2Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.3.tgz",
-      "integrity": "sha512-z6eEvJ5HIb0aFqVldHyU5Guut+bv/opu28i+rrfDb1LEG3IWk5T3DbW9d/nWpAfNze/bjwiZvPphmkuycijb2w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.12.0.tgz",
+      "integrity": "sha512-L6JaaeNjG6J5Ros4MLd+Yb2ZS0RhfJ5fj8w5UtCyf1I0cnwJo7hrRExE5RWXVBtF5nl8mO3eIGUe959hC1DtVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
-    "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.3.tgz",
-      "integrity": "sha512-HTISScqScdnUc2BKqMaWM+ISU79AlHlr+XHUR9g0R8QiO4KzCkWUi6TncP0gvGoEY+BvfR0OkztfxYrelkksmg==",
+    "node_modules/@swagger-api/apidom-ns-a2a-1": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-a2a-1/-/apidom-ns-a2a-1-1.12.0.tgz",
+      "integrity": "sha512-kYfltECH/D3+bT+7IxYtF7VGNrSeDqqDttiIjx7R3pBgPPbxNWAi/EA4Rx+c7qY56sDz0CdbtZNTH28bNi00og==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-api-design-systems": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.12.0.tgz",
+      "integrity": "sha512-opXxaAZGxy/IDdUxqfTugtoGeKarb+pDchdVMOWNUD4NZH5weE519dcqCdLMqWtcHX2RL2m9UdcJjGLnAt+GQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -390,15 +405,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.3.tgz",
-      "integrity": "sha512-AHRSbuYy5oA8c/7j7nahxMASjt0cuOWyUk4yu+cKG+KS85ho2f2NiFThqQjtIJLisvrp+qNniJ1EwTfcCTivTQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.12.0.tgz",
+      "integrity": "sha512-xqtr7pZ5IQBsHZA6yWbSprVSTzpIbM5FtX40rY7lx4wsm4TyhIfJBxOf99+jFmELt7QHoKCUZ8zZQOdf+uOqLw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -406,15 +421,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.3.tgz",
-      "integrity": "sha512-bn/Pf52SCsSGcw7qO3gAje+KjhhpWJxWjjWQe5Jv9oPoXCnvGoSspSXMY3zIrhz9XfrP94AdWBUpOlWBoaaDBQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.12.0.tgz",
+      "integrity": "sha512-xe3Y3PeRqohaOinEtKTqnUxPoMAopTYAPEnXew5qRcnH7wVWO99J3+XrbY+x9JEXhcAKHpKSWmuNx5o7oU0WdA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -422,15 +437,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.3.tgz",
-      "integrity": "sha512-QhZtf8YeMRVtgVioJj0qKdNG0LEzi9RPSrC9KWfCdwEBlkhNDhHFh6FIJWayYAwR6DPlOXjTYQf97V9QwIuRmQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.12.0.tgz",
+      "integrity": "sha512-WZ/j/Hk8nsX0lkHiTUFfESkQgGGEba9dwiKMP9OvX9qLsoxJ04Dg1Z7E58WCrmwistEpynMHO+KY3qo2trWOUQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -438,15 +453,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.3.tgz",
-      "integrity": "sha512-zHA4/oin6Fg6VN0bWmMRu1nt4Xnd05mF5T+Od6vEmid1bxDXpfSSMaPpdu+WCBJ5dDX19EeBVTJoAI0U4psxBg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.12.0.tgz",
+      "integrity": "sha512-fWRjOvOiOFqKp0vJgFJn1fm9i+H5eSOQ1J0xWldTnHJPHsYPQkYPLAQdpXcBbBiB5o0JYVeJe7PyWv3DvNxqSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -454,15 +469,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.3.tgz",
-      "integrity": "sha512-zUWRb5DlvlZXtf2JmiNqUwwgGc4eUAsUQPU59kP140vkPT98HDhNJx9UXoHLgP5F/Zk8f2rzeG237u+JnCT9/g==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.12.0.tgz",
+      "integrity": "sha512-U0sv+7aD6njyxcvQOS9Lkpr4feJRowMn0/shiIlXrXY1ox3BDJBgipsgx/0IqfQNseP3Zj43Ec5kGk4PFmsjCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -470,14 +485,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.3.tgz",
-      "integrity": "sha512-udOM8ZQT7BzsyT9012R7/VjeazjOlyLwKpmpbgHZDG6uGHqsnWn9lN+F8/5Eox9qqBnQNqDNtDhBEMYjE6RYNQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.12.0.tgz",
+      "integrity": "sha512-c+NYp+DZvoZ0+3hFgKhQn507kba0HUv8C60cJEqQPCpIKqKpWvpZ6YF8GsKVhJoML4PAr6Zl6SWjFVvOnDUbBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -485,15 +500,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.3.tgz",
-      "integrity": "sha512-ZOgo5OtpQ6e5XQ5R1H8CYTYXEtnD0l+FyN065A6c2O1NxJXFKS2a5SZTvx+udA4mugtkTSmr7hAQe2ae+KAXQw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.12.0.tgz",
+      "integrity": "sha512-O8aM7l/+K2ej3AH6f7NbEVADAuZhulLWmAGFFwRBHvE022mUeOQiDrcA1cd5q/s8fY+UFE+GIrfVAq0aBPLvxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -501,15 +516,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.3.tgz",
-      "integrity": "sha512-L5Sc0qMUrUbgVex3fN+tnNHjed/JCAwpwyzdHY8KgUfXHkfM5aLUyyAGirm+ObwZvGDEejsTT2Otp6B5S29eqw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.12.0.tgz",
+      "integrity": "sha512-gWTTBmz6CyBytc4v7tMcm0KJ/0xp8n0zyWE1VSBXvLjFylOfvlkzmPL/MD8sqiEqUCGXXSQAyUmyL7heU8uGzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -517,16 +532,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.3.tgz",
-      "integrity": "sha512-T241UD+1My1hVJHayTCz9f7rznmeM8rxQW4NtUnD8k677SShpnNkrfeoc1elrpJXdTsnEPIOLCK0EEIyEplHgA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.12.0.tgz",
+      "integrity": "sha512-eISSf1rj7/HZAzOBGdZneUNp4M3FPwvqmKFL9ODBN+kpKFQ438TnYPdMVm60EoiinpvKa7hrKVKj/RubDfvcIQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -534,15 +549,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.3.tgz",
-      "integrity": "sha512-FZvBqWpZFciemMgWBGY89RIH5uLl6ZYtmMAhWzDcmEi1JSjmWKkoqZno//KlqSgbI09gbkzipdMjGK825givPA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.12.0.tgz",
+      "integrity": "sha512-8DqRCkRTxQPtFjRjWiFo5F/IZcBqFFcqjmtoVWbxkUNGyJpgfZjx5Mne/QCB9ZV5vqNeBPF2IYfjQZEvgOBKvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -550,17 +565,17 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.3.tgz",
-      "integrity": "sha512-ObCP+l3/ZhuPaSqXqmSnCpEOIMalQns0c4IZgX6h3o7Jc6K6BcqDMeq4s17dwcQja9fFUtkoIIFuquJBKvK86Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.12.0.tgz",
+      "integrity": "sha512-6h4NJyCb/I9GkPYCma7SiEp3MlMNH9DFDntamb49AJDBNlibOG1VyR+y3R4+vzUlYOZayMDwe7Z1zC+qN0ulYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-json-pointer": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -568,163 +583,195 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.3.tgz",
-      "integrity": "sha512-Ri7KLrfrpJeteghUdzbozxKve2NG5Z1aPWX91DI14j75+v/xBAu91AIZt7K+LV8JWUNk+VbhUlhgSH1JAIVa0g==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.12.0.tgz",
+      "integrity": "sha512-kkrXfvRPpiJTcK6qr0dB5Jf80kD3jgTo1DU9W6Q5/n06WcyGQhtKTofY7YRHQ52r2Nfpuh9JbxtoD0PIHE0STQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-json-pointer": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.3.tgz",
-      "integrity": "sha512-6LcwiY2Ce1qmsq8CSxCoRMJ3q2quFnEsNgI48LpM9/PYK/idjsB/WrnU9xSl9fXm/aTo/bOO0ckc8KadxVykfA==",
+    "node_modules/@swagger-api/apidom-parser-adapter-a2a-json-1": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-a2a-json-1/-/apidom-parser-adapter-a2a-json-1-1.12.0.tgz",
+      "integrity": "sha512-RwUkRb92938NiTriueninR0MaeXYJRZKcZtYyEB5h2JRQ7nQGsCO6a6F1rNwehzLoPeRWLGMYr0wRWP1tTy7fw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-a2a-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-a2a-yaml-1": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-a2a-yaml-1/-/apidom-parser-adapter-a2a-yaml-1-1.12.0.tgz",
+      "integrity": "sha512-G2L1mRcuAJQICU18cjYH6FIZshYVJOCAmz5JSNknriIL0LYXr8xlbQ7kStTC5cmM9YfxDfD3eLb92vQ+yvpbCA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-a2a-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.12.0.tgz",
+      "integrity": "sha512-Co9BcoTlEAcrDIVTE/o0B6+HAlIuwB5hvKMs+w9+P+r6cSDRqx4NOi16iqBH6leCEtO6xU8H152ua0e8hKkQSQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.3.tgz",
-      "integrity": "sha512-zk2NuWAOvjEHYQ3lZ43VhAqJk+9KK452HeFfZFne4a4iALhCQ/wceK7tCG81jBMMoWnR0f1JS/vxz7/Y2CNwLA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.12.0.tgz",
+      "integrity": "sha512-vBnmuMflgcxPkqQX8rXFIWU6GdC0OPMO73LU4iOOjG2kxycET6NTs0zu6mTKRwfCk7PmVR+MzaqLyORCkL3Rjw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.3.tgz",
-      "integrity": "sha512-vXP6lYp6Q5/5nLkMJyBRTWYIZYxL6GnOsJsdnN0KdTHuoPXNZWsv5p2oPYlVE/W7gRAZDylUmYZQ1L9rr7BGRw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.12.0.tgz",
+      "integrity": "sha512-5SHEWHdLXpbugsDN2NVYxqh87Sson4pDS+Yk9Zp00cJSl2dNtLZ+LHq3dtIgjFcKy9yOCnaiKjzqoZtpdQB1zQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.3.tgz",
-      "integrity": "sha512-zI57Q5DIf7TGv1A2gIk3umbPWMEFWYO3tEmfP0xJGDBn6gZRHgJvvVjn0wQrljigEEw1V3hRDUXk6Zzg3oVNvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.12.0.tgz",
+      "integrity": "sha512-l0ocWS0IcWYx0ZFosEQguOS72dJXYnEC42KrQgYJMvZCfpMZPtP4HahAYryFxRZWiHZnhunkSChv8MRnBplcQA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.3.tgz",
-      "integrity": "sha512-VGl15mpHaL+SlsXaRvcVaWXir+pCLrj99QN//Kuir3cpPW6P9IdBztj11bjoIG3aX1bOIrU16/uOhV4G5J4Kag==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.12.0.tgz",
+      "integrity": "sha512-oZt3H7qH4ttU+RILLQ8G8tgOLe+hRMQDh7q/W/Dfxc2xGGsLb6jYG4gl45ry/QHDpudCc2SKC3GxdXfQ3Dl4pg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.3.tgz",
-      "integrity": "sha512-37dNwdLAcAd7TZW8YqSbpuBoujfoM2AvXBoT1BUxzbYetwNkxP19Q1VtCEAzMxUEQ/9niBANSzuo0zClUEc2kw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.12.0.tgz",
+      "integrity": "sha512-O4osrUo/q0ErGPqmCHfYEdRpeH894Dix0AQwLwuovgIS5OxWMa2r6Z8mzz3emRoyVi9ucF+0//OFm7WeU7NcGg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.3.tgz",
-      "integrity": "sha512-MEZHn+qROKehrXLhDhl7kSQADXjwU2NGSeNuBTr1/nINShpu4Tkxrk7xT0LY8GauKrZR9MyAnueATDQgK8NWhQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.12.0.tgz",
+      "integrity": "sha512-AfcdwWREQhBAEbVTwIVjFLvW/j5wTXmY8/VkKp1OmF7zXyyZDMA+xRAoGZlOlc+KNJ46O6yeN9CLfUaJ0IoRog==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.3.tgz",
-      "integrity": "sha512-qHOK0NXnG7t5Gx0xCIbyfrM5FXLgK6krlZRPlrlT6K853MWWWWmjAieuayPtu72Ak1hd/8U2/oWgbONnPqj76w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.12.0.tgz",
+      "integrity": "sha512-+gAKV6dwr1neG3ngONPYWYRATrYD/ooRO+dY6kOgc2yy99YagtSZjtNNSosvoMdPL8vhI6OkZRyew41kyW+Vwg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.3.tgz",
-      "integrity": "sha512-Wj/DTb6mblsaxKfye9kXLwS+KmWWLAM2M2oSs4muOclhAOtcffr2H+STtiT3Hwrzb+cW8RpX6Htvey4rvbj/Jg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.12.0.tgz",
+      "integrity": "sha512-Tftr63g71VwTsWtafYgI7xrmkp6lcs8p6hwo06UzZICTyEsfMrye6Hjvs2TM0KBO/e6Hw8cTdCIBVtEV10Knqw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -734,144 +781,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.3.tgz",
-      "integrity": "sha512-aDR5vKSApqQgDkvJNJZqvp8slEWHGByz5bzDbw6ZHRPSIZcA2IEHdJPgWJVS5gNtJ+YAnA7veM39oqeoF2yy8w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.12.0.tgz",
+      "integrity": "sha512-2cMgq3NBAS7magAFqgtBZOoi3vRR7/txQOOA1nzEODiS4WV4ERbe2B59+uaQ7+yzJlkm0OPqzFhXy3IkOB6Z0g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.3.tgz",
-      "integrity": "sha512-hpSBiaVG7qbyJy25/Pl48NCT9uvvsOPAAj+xCAb9TwmIPBcFkVYvj6ZWJbYZsOmzUzcNLOZEOBjRNPN3G31zmQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.12.0.tgz",
+      "integrity": "sha512-ws5vsTv8KtrwzPPGwyeNUrEGYLlsRSByTWHFXH8hU8eGbSAcmmKsENhNeEjslimzD2Cev5vJzmdat5oWpKY4fA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.3.tgz",
-      "integrity": "sha512-EP7U25s5We8Q/2olymVrJL2nKT+skTea6SnR8F3OETsBoef3i1XgQx7AHqUc9S83hp+bOxZ+oPyI6dNwO+J+MA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.12.0.tgz",
+      "integrity": "sha512-C2/oMuyGarGAPQj5Taob9MOI9Hme6D5Qm/ZyJkRgXBg50ZA3WeaFCr51St6dNU1lDhe8i++cZeWMsp4wegPllw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.3.tgz",
-      "integrity": "sha512-WLuMb0pwH+5hjosRHGvUFLm9iWP0/XNnEdrwdUio4y0eodjDwrPGb2LSdH3zaR8p7mKrqe007jqpjaLLsStzrQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.12.0.tgz",
+      "integrity": "sha512-kuSIq/Tht5LQ2lezsz6O1x+PM1U5DWeZBQKqHkTgQokhsbxM9dmO6xmSW/aQUk+0jUWf8n6ROrGmscrw6AawWg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.3.tgz",
-      "integrity": "sha512-PyD0E4fwOhOCcP/Aqa9HlvZYuw825E6N0IRC69dxxt6Fy6w6Fv2KYRnRw8OINoog8I6/8uSZOLdeDla3FCqhFA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.12.0.tgz",
+      "integrity": "sha512-QR0XdBWzjN/8ZmgBrbswP+Bpj+BllUqFiJu43VZNm1M8u/AtbJnsdlTw3coXLVpVpV7ruAKjp0GtsqQyOKNA1w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.3.tgz",
-      "integrity": "sha512-7ULkLaEAAVKRNWT525PdKOaUjrZ7G2ulH9VBsMJ9niaZN/n6hnSW8IR4Iaf0cLZ1MjsZsdWovq5slPz2hpqR4A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.12.0.tgz",
+      "integrity": "sha512-2Mzft9tXXodoRBqEEXQ1p5MRLrzIDt7SCqZyXF9cBF5ukIdHfgq7vDoX7XUECELzhCf3mMRxLaxH+JcPC26izg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.3.tgz",
-      "integrity": "sha512-2VqxGS0PaNrYeLgGyOl9m4m6EbJjrtxOswzWK2Rk3/M3gEDfnFdyOVffKWlcdEv6XFJ+wgLy5MPlODrzyOOKCA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.12.0.tgz",
+      "integrity": "sha512-dYrUHnD7r6uhsh2H+gMwxFTSaqSADFHmpG1tFi7b7m/aFbNFCppB63iJ7LYg9Ew6IBej9WrYkr2jXDLKBgsMaA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.3.tgz",
-      "integrity": "sha512-fRJYMozAyIJP46kKbUPQX2wIzfX9FSC7ZxUn+VWOa587f3zZC3XmydGO46GA/TGuc8cWs7AFD/EfSKWDbsB3Tg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.12.0.tgz",
+      "integrity": "sha512-KrNSQmsmp6iO2o+AxJ9jpwKd4lVmPIaDcWrbp4se5b1MnHUmtf7d7h9kvI5pXhGFGuyA59HMp6qQzNfuS5SMEA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.3.tgz",
-      "integrity": "sha512-mSPMfVzDkLC+HPDI/6ho8TxI1PEcDJl/Y53gZdmfCU1xYzUdOF4s0iHalHHt0ipxYpt0EQXD+oGBnpp/TTx4IQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.12.0.tgz",
+      "integrity": "sha512-vydWYSj1I0t4fsBeu7nAieivBKsW2A7KW9keS+osXLuyYWs1GLHdby5AXRHPv6ktR507vAq8RxQUXkODRxyRCg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
@@ -913,46 +960,49 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.3.tgz",
-      "integrity": "sha512-Y0J+pAru/Est0wQJlFeQq2AsWyboOJP456Zv2wV4m0Ib1QY6N2wWiL6clkHpHA0pughemN6gcjBeNlMeRGqXuw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.12.0.tgz",
+      "integrity": "sha512-GApJUvwLROSyM2KfbdvuV/zC6ccb54khvhy2eJ7jPhAk5FU0zZE5Ijt0NmY5nSf97sET87MjrWgCCMszdqPXfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
-        "axios": "^1.16.0",
-        "minimatch": "^10.2.1",
+        "axios": "^1.18.0",
+        "minimatch": "^10.2.6",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^1.11.3",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3"
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-a2a-1": "^1.12.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-a2a-json-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-a2a-yaml-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
@@ -965,24 +1015,24 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2050,13 +2100,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -2572,11 +2622,14 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.50.0.tgz",
+      "integrity": "sha512-6GP3Pxz4IKyWjAfa747vIu/jilB5z29JWROLqH/b+pXVcpgh6tM06ZIBwSuglgVqzDYURhOK6oEzTrG0bCHitA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -2791,9 +2844,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3799,9 +3852,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+      "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
@@ -3918,13 +3971,10 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
-      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4304,9 +4354,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -4591,9 +4641,9 @@
       "license": "MIT"
     },
     "node_modules/neotraverse": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -4606,9 +4656,9 @@
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
-      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5835,24 +5885,24 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.37.7",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.7.tgz",
-      "integrity": "sha512-AzmF/FDSPYBcoxXarHPnqK3lSXoKH9Fh0EjLHAlP0h/D7EG1Fofl/wEuGqhYT+IBpriu3mSgWCh2xAftsYdL8w==",
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.38.0.tgz",
+      "integrity": "sha512-n7aykm1BEdQ3fKePJJx63UGjYe8/5fuxFMi3qZP4OJGZvzljKvmhxNwIF/MB71sF/lop9NeWZReKvPib9CY+2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
         "@scarf/scarf": "=1.4.0",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-json-pointer": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
-        "@swagger-api/apidom-reference": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-reference": "^1.12.0",
         "@swaggerexpert/cookie": "^2.0.2",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
         "js-yaml": "^4.2.0",
-        "neotraverse": "=0.6.18",
+        "neotraverse": "=1.0.1",
         "node-abort-controller": "^3.1.1",
         "openapi-path-templating": "^2.2.1",
         "openapi-server-url-templating": "^1.3.0",
@@ -5863,33 +5913,33 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3"
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0"
       }
     },
     "node_modules/swagger-ui": {
-      "version": "5.32.10",
-      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.32.10.tgz",
-      "integrity": "sha512-1MpHIJfXkqQMKhLh9HsA8frW1hOvwhlSzB3AFJpSWGVlZpvdvyiYJzvsINV8+BHEyol54sMB1Ma78UW6rsXNsg==",
+      "version": "5.32.13",
+      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.32.13.tgz",
+      "integrity": "sha512-A45WgFf4JcjM+HEbmzApdlggvR0YzH27hbjccy1DmLT0XVGnrH7q6zzD3is140YIv1tau1YGB/yHD244uxh2Sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.27.1",
@@ -5899,11 +5949,11 @@
         "classnames": "^2.5.1",
         "css.escape": "1.5.1",
         "deep-extend": "0.6.0",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.13",
         "ieee754": "^1.2.1",
-        "immutable": "^3.x.x",
+        "immutable": "^4.3.9",
         "js-file-download": "^0.4.12",
-        "js-yaml": "=4.3.0",
+        "js-yaml": "=4.3.1",
         "lodash": "^4.18.1",
         "prop-types": "^15.8.1",
         "randexp": "^0.5.3",
@@ -5923,7 +5973,7 @@
         "reselect": "^5.1.1",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.12",
-        "swagger-client": "^3.37.7",
+        "swagger-client": "^3.37.8",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",


### PR DESCRIPTION
Clears 4 of the 5 advisories reported by `npm audit` (3 high, 1 moderate).

**Lockfile-only change** — both packages were already inside their existing `^` ranges in `package.json`, so nothing but the pins moved. No API surface change.

| Package | Before | After |
| --- | --- | --- |
| `swagger-ui` | 5.32.10 | 5.32.13 |
| `highlight.js` | 11.11.1 | 11.12.0 |

## Advisories resolved

All four came in transitively through `swagger-ui`:

| Advisory | Severity | Package |
| --- | --- | --- |
| [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) — IN_PLACE hook removal leaves detached subtree executable (XSS) | moderate | `dompurify` |
| [GHSA-v56q-mh7h-f735](https://github.com/advisories/GHSA-v56q-mh7h-f735) — `List` 32-bit trie overflow → unrecoverable DoS | high | `immutable` |
| [GHSA-xvcm-6775-5m9r](https://github.com/advisories/GHSA-xvcm-6775-5m9r) — hash-collision complexity DoS in `Map`/`Set` | high | `immutable` |
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — unbounded expansion DoS | high | `brace-expansion` (via `@swagger-api/apidom-reference` → `minimatch`) | 

Worth noting the dompurify XSS is real exposure rather than a build-time-only finding: `swagger-ui` is vendored into `static/dist/` by gulp and shipped to the browser on the `/api/` docs page.

`npm audit` goes from **5 vulnerabilities (4 high, 1 moderate) → 1 high**.

## Remaining advisory (not fixable here)

The survivor is `brace-expansion@1.1.16` via `eslint@9`'s pinned `minimatch@3`:

```
eslint@9.39.5 -> minimatch@3.1.5 -> brace-expansion@1.1.16
```

It's **build-time only** (never shipped to the browser) and needs the `eslint` 9 → 10 major, which is a separate change with its own config-migration risk. Deliberately left out of this PR to keep it a zero-risk lockfile bump.

## Testing

- `npx gulp swagger-ui` copies the new bundle cleanly.
- Rendered the upgraded bundle against the repo's `swagger.yaml`, initialised exactly as `templates/api.html` does (same presets and `DownloadUrl` plugin): the full spec renders — title/version header, Authorize button, servers dropdown, and all endpoint groups (Status, Auth, Files, …). No console errors or exceptions.
- The real `/api/` view is `@login_required`, so it was exercised via a standalone harness using the vendored `static/dist/swagger-ui/` assets rather than through an authenticated session.
