### PR TITLE
Bump jquery to v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "gulp": "^5.0.1",
         "gulp-download2": "^1.1.0",
         "highlight.js": "^11.11.1",
-        "jquery": "^3.7.1",
+        "jquery": "^4.0.0",
         "jquery-ui": "^1.14.2",
         "js-cookie": "^3.0.8",
         "leaflet": "1.9.4",
@@ -4233,9 +4233,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
       "license": "MIT"
     },
     "node_modules/jquery-ui": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp": "^5.0.1",
     "gulp-download2": "^1.1.0",
     "highlight.js": "^11.11.1",
-    "jquery": "^3.7.1",
+    "jquery": "^4.0.0",
     "jquery-ui": "^1.14.2",
     "js-cookie": "^3.0.8",
     "leaflet": "1.9.4",


### PR DESCRIPTION
## Why jQuery first

Of the three outdated packages left after #430 (jquery, swiper, datatables.net family), jQuery is the lowest-risk to move: a repo-wide grep of `app/static/js` turns up zero direct jQuery API usage — no `$.ajax`, `.bind()`, `.delegate()`, or any of the other APIs jQuery 4 removes. The only references are JSDoc type annotations (`@param {jQuery}`) in `main.js` / `file-context-menu.js`. Bootstrap 5 and datatables.net 2.x also don't require jQuery, so this is close to a no-op for runtime behavior.

## Change

- `jquery`: `^3.7.1` → `^4.0.0`

## Validation

- `rm -rf node_modules package-lock.json && npm install` — clean, no warnings
- `rm -rf node_modules && npm ci` — clean, no warnings; resolved `jquery@4.0.0`
- `npm outdated jquery` — no output (fully current)
- `npm run lint` — pass
- `npx prettier --check package.json package-lock.json` — pass
- `npx gulp jquery` — pass (dist assets are gitignored/generated, nothing to commit there)

## Follow-ups (not in this PR)

- swiper 12.2.0 → 14.1.0 (isolated to the album slideshow feature)
- datatables.net + 5 sibling packages 2.x → 3.x/4.x (touches ~22 files across nearly every table view — needs a dedicated PR and full regression pass)