### PR TITLE
Bump swiper to v14.1.0

### DIFF
--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -873,7 +873,12 @@ async function addNodes() {
     if (nextPage) setupScrollObserver()
 }
 
-const imageExtensions = /\.(gif|ico|jpeg|jpg|png|webp|jxl|avif)$/i
+// JXL/DNG are deliberately excluded from server-side thumbnailing (see
+// home.tasks.generate_thumbs's thumb_exclude) because Pillow can't decode
+// them, and no mainstream browser can render the raw file inline either —
+// so treat them as generic (icon) files here rather than attempting an
+// image thumb that's guaranteed to fail.
+const imageExtensions = /\.(gif|ico|jpeg|jpg|png|webp|avif)$/i
 
 function addGalleryFile(file, top = false) {
     if (file.mime?.startsWith('video/')) {

--- a/app/static/js/slideshow.js
+++ b/app/static/js/slideshow.js
@@ -133,9 +133,11 @@ function buildLazyPreloader(img) {
 
 function hydrateVisibleSlides(swiperEl) {
     if (!swiperEl) return
+    // .swiper-slide-visible catches every slide in view on the thumbs strip
+    // (slidesPerView: 5) — active/prev/next alone only tags 3 slides.
     swiperEl
         .querySelectorAll(
-            '.swiper-slide-active img[data-src], .swiper-slide-prev img[data-src], .swiper-slide-next img[data-src]'
+            '.swiper-slide-visible img[data-src], .swiper-slide-active img[data-src], .swiper-slide-prev img[data-src], .swiper-slide-next img[data-src]'
         )
         .forEach((img) => {
             if (!img.src) img.src = img.dataset.src

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "moment": "^2.30.1",
         "qr-code-styling": "^1.9.2",
         "swagger-ui": "^5.32.10",
-        "swiper": "^12.1.4",
+        "swiper": "^14.1.0",
         "tsparticles": "4.3.2",
         "ua-parser-js": "^2.0.10"
       },
@@ -5887,9 +5887,9 @@
       }
     },
     "node_modules/swiper": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.2.0.tgz",
-      "integrity": "sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-14.1.0.tgz",
+      "integrity": "sha512-ppit/AqmGvThKlXy4I1/9N/gEyb9s/BDHWciWNeIxbfteFKUhPQXrYuOMKszomXKd9WiLd+/0vKdPHW+0N0mhA==",
       "funding": [
         {
           "type": "custom",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "moment": "^2.30.1",
     "qr-code-styling": "^1.9.2",
     "swagger-ui": "^5.32.10",
-    "swiper": "^12.1.4",
+    "swiper": "^14.1.0",
     "tsparticles": "4.3.2",
     "ua-parser-js": "^2.0.10"
   },


### PR DESCRIPTION
## Summary
1. Bumps `swiper` from 12.2.0 to 14.1.0 (jumping the 13.x release along the way).
2. Fixes the slideshow thumb-strip filmstrip showing broken images for several thumbs.
3. Fixes gallery grid thumbnails failing to load for `.jxl` files.

Both bugs were found while smoke-testing the swiper bump; neither is caused by the version bump itself (confirmed the same logic exists independent of swiper version), but they're small enough to bundle here rather than open more PRs.

## 1. swiper bump
- Swiper usage is fully contained: only `app/static/js/slideshow.js` and `app/templates/include/albums-slideshow.html` reference it — no other file touches the API.
- The project consumes the prebuilt `swiper-bundle.min.js`/`.css` UMD bundle via gulp, not the ESM package exports, so the v13/v14 "ESM-first" restructuring doesn't affect this build.
- Confirmed the v14 bundle still exposes a global `Swiper` constructor and still includes the `fade` effect, `Thumbs`, and `Lazy` modules that `slideshow.js` relies on.
- No calls to any APIs removed between v12 and v14.

## 2. Slideshow thumb-strip broken images
`slideshow.js` lazy-loads slide images itself (`data-src` → `src`) instead of using Swiper's built-in lazy module, promoting only slides tagged with Swiper's `.swiper-slide-active`/`-prev`/`-next` classes — each of which applies to exactly **one** slide. The thumbs strip runs `slidesPerView: 5`, so 5 thumbnails are visible at once but only 3 ever got hydrated; the other 2 sat permanently with just a `data-src` and no `src`, rendering as the browser's native broken-image glyph + filename (not our custom placeholder — this bug bypasses that entirely since it's not a network failure, the `<img>` just never got a `src`).

Fix: also hydrate `.swiper-slide-visible`, which Swiper assigns to every slide currently in the visible window when `watchSlidesProgress: true` (already set on the thumbs swiper only, so this doesn't change the main image swiper's single-slide prefetch behavior).

## 3. `.jxl` gallery thumbnail fix
`home.tasks.generate_thumbs` deliberately excludes `image/jxl` (and `.dng`) from server-side thumbnail generation, since Pillow can't decode either format:
```python
thumb_exclude = Q(mime__in=["image/jxl", "image/x-adobe-dng"]) | Q(name__iendswith=".dng")
```
But `gallery.js`'s `imageExtensions` regex still listed `jxl` as a browser-renderable image type, so `addGalleryImage` was used for `.jxl` files. With no thumb ever generated, `img.src` fell back to `file.raw` — the full-size `.jxl` file — which no mainstream browser can decode natively either.

Fix: drop `jxl` from the frontend's renderable-image extensions, same treatment `.dng` already got.

## Validation
- `rm -rf node_modules package-lock.json && npm install` — clean, 0 vulnerabilities, `npx gulp` regenerated `dist/swiper/*` successfully.
- `rm -rf node_modules && npm ci` — clean.
- Verified minified v14 bundle source directly for global `Swiper` export and `fade`/`Thumbs`/`Lazy` presence.
- Confirmed the thumb-strip hydration gap by reading `hydrateVisibleSlides` + the thumbs `Swiper(...)` config (`slidesPerView: 5` vs. active/prev/next only ever tagging 3 slides) — matches the reported filmstrip screenshot exactly (broken-image glyph + filename, not our JS placeholder).
- Reproduced the `.jxl` bug against the local dev stack's real seeded data (DB: the one `.jxl` file present had `thumb=''`, and `generate_thumbs`'s own query explicitly excludes `image/jxl`/`image/x-adobe-dng`).
- `npm run lint` — clean.
- `npx prettier --write` — no changes needed beyond the edited files.

Still worth a visual pass on the deployed slideshow filmstrip before merge to confirm all 5 visible thumbs load, but the fix follows directly from Swiper's own visibility-class semantics.