### PR TITLE
Fix header jump and blank-table regressions from the DataTables bump

### DIFF
--- a/app/static/js/file-table.js
+++ b/app/static/js/file-table.js
@@ -327,12 +327,7 @@ export function addFileTableRow(file) {
 export function addFileTableRowsBatch(files) {
     if (!filesDataTable) return
     if (!files.length) {
-        // Nothing to add. If the table is currently empty, still force a
-        // draw so DataTables renders its "no records" placeholder — without
-        // this, a sort/filter reload that legitimately matches zero files
-        // leaves tbody permanently blank: clear().draw()'s own placeholder
-        // row was already stripped out by showTableSkeletons()'s cleanup,
-        // and nothing else ever redraws to put it back.
+        // Redraw anyway if empty, so the "no records" placeholder appears
         if (filesDataTable.rows().count() === 0) filesDataTable.draw(false)
         return
     }

--- a/app/static/js/file-table.js
+++ b/app/static/js/file-table.js
@@ -327,7 +327,7 @@ export function addFileTableRow(file) {
 export function addFileTableRowsBatch(files) {
     if (!filesDataTable) return
     if (!files.length) {
-        // Redraw anyway if empty, so the "no records" placeholder appears
+        // without this draw a zero-result filter leaves tbody blank forever
         if (filesDataTable.rows().count() === 0) filesDataTable.draw(false)
         return
     }

--- a/app/static/js/file-table.js
+++ b/app/static/js/file-table.js
@@ -325,7 +325,17 @@ export function addFileTableRow(file) {
 }
 
 export function addFileTableRowsBatch(files) {
-    if (!filesDataTable || !files.length) return
+    if (!filesDataTable) return
+    if (!files.length) {
+        // Nothing to add. If the table is currently empty, still force a
+        // draw so DataTables renders its "no records" placeholder — without
+        // this, a sort/filter reload that legitimately matches zero files
+        // leaves tbody permanently blank: clear().draw()'s own placeholder
+        // row was already stripped out by showTableSkeletons()'s cleanup,
+        // and nothing else ever redraws to put it back.
+        if (filesDataTable.rows().count() === 0) filesDataTable.draw(false)
+        return
+    }
     files.forEach((file) => {
         file['DT_RowId'] = `file-${file.id}`
     })

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -427,12 +427,24 @@ async function resetAndReload() {
     // relying on JS timing — it un-hides on its own once real rows (or a
     // genuinely empty result) land.
     const tableNode = filesDataTable?.table().node()
-    tableNode?.classList.add('dt-reloading')
+    if (tableNode) {
+        // Between clear().draw() and the skeleton rows landing, tbody has no
+        // visible rows at all — the table (and the sticky header anchored to
+        // it) briefly collapses to header-only height, then snaps back once
+        // rows repopulate. That collapse-and-snap is what reads as the header
+        // row jumping. Pin the table's current height across the reload so
+        // it never collapses in the first place.
+        tableNode.style.minHeight = `${tableNode.getBoundingClientRect().height}px`
+        tableNode.classList.add('dt-reloading')
+    }
     if (filesDataTable) filesDataTable.clear().draw()
     try {
         await addNodes()
     } finally {
-        tableNode?.classList.remove('dt-reloading')
+        if (tableNode) {
+            tableNode.classList.remove('dt-reloading')
+            tableNode.style.minHeight = ''
+        }
     }
 }
 

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -421,8 +421,7 @@ async function resetAndReload() {
     fetchLock = false
     hideSkeletons()
     galleryContainer.replaceChildren()
-    // dt-reloading hides the empty-table message (table.css) and pins
-    // min-height so the table can't collapse and un-collapse mid-reload.
+    // without the pinned height, the header visibly jumps as rows clear/reload
     const tableNode = filesDataTable?.table().node()
     if (tableNode) {
         tableNode.style.minHeight = `${tableNode.getBoundingClientRect().height}px`

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -421,19 +421,10 @@ async function resetAndReload() {
     fetchLock = false
     hideSkeletons()
     galleryContainer.replaceChildren()
-    // .clear().draw() renders DataTables' own "No files" placeholder before
-    // addNodes() gets a chance to swap in skeleton rows. Hide it via CSS
-    // (table.css .dt-reloading) for the duration of the reload rather than
-    // relying on JS timing — it un-hides on its own once real rows (or a
-    // genuinely empty result) land.
+    // dt-reloading hides the empty-table message (table.css) and pins
+    // min-height so the table can't collapse and un-collapse mid-reload.
     const tableNode = filesDataTable?.table().node()
     if (tableNode) {
-        // Between clear().draw() and the skeleton rows landing, tbody has no
-        // visible rows at all — the table (and the sticky header anchored to
-        // it) briefly collapses to header-only height, then snaps back once
-        // rows repopulate. That collapse-and-snap is what reads as the header
-        // row jumping. Pin the table's current height across the reload so
-        // it never collapses in the first place.
         tableNode.style.minHeight = `${tableNode.getBoundingClientRect().height}px`
         tableNode.classList.add('dt-reloading')
     }


### PR DESCRIPTION
Follow-up to #433 — two regressions reported after that merge, both in the List view's sort/filter reload path (`resetAndReload()` in `gallery.js`).

## Header row jumps on sort click

Reproduced and root-caused live: between `filesDataTable.clear().draw()` and the skeleton rows landing, `tbody` has zero visible rows. The `<table>` (and the sticky header anchored to it) briefly collapses to header-only height, then snaps back once rows repopulate — that collapse-and-snap is what reads as the header jumping.

Confirmed via a live measurement of `thead`'s `getBoundingClientRect().top` across a sort click: it dropped from 43px to 36px for one frame, then back to 43px.

Fix: pin the table's height across the reload window so it never collapses in the first place.

## Table stays permanently blank on a zero-result sort/filter

This turned out to be worse than a flash — reproduced live by filtering to a combination with 0 matches (Executables + Private): `tbody` ends up completely empty, not even DataTables' own "No files available" message.

Root cause: `addFileTableRowsBatch([])` early-returned before ever calling `.draw()`. `clear().draw()` creates DataTables' empty-placeholder row, but `showTableSkeletons()`'s cleanup immediately strips that row out to make room for skeletons. When the fetch then legitimately returns 0 files, nothing ever redraws to put the placeholder back — `tbody` is left permanently empty.

Fix: when the batch is empty and the table currently has 0 rows, force a `draw(false)` so DataTables re-renders its own empty-state message.

## Verification

Both fixed and verified live against the local docker-compose dev stack (mounts the working tree live):
- `thead` position measured via injected `MutationObserver` across sort clicks — no more transient shift, stays pinned throughout the reload.
- Empty-result case tested via Filter → Executables + Private (0 matches): "No files available" now renders correctly instead of a blank table.
- `npx prettier --check` and `npx eslint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)