### PR TITLE
Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Expand Override Tags"
         id: override

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Expand Override Tags"
         id: override

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Sanitize Tag"
         id: tag

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Sanitize Tag"
         id: tag

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Debug"
         run: |
@@ -41,7 +41,7 @@ jobs:
           cat ${{ inputs.COMPOSE_FILE }}
 
       - name: "Checkout Service Configs"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: "hosted-domains/service-configs"
           ssh-key: ${{ secrets.SERVICE_CONFIGS_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Debug"
         run: |
@@ -41,7 +41,7 @@ jobs:
           cat ${{ inputs.COMPOSE_FILE }}
 
       - name: "Checkout Service Configs"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: "hosted-domains/service-configs"
           ssh-key: ${{ secrets.SERVICE_CONFIGS_KEY }}

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Draft Release Action"
         id: draft

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Draft Release Action"
         id: draft

--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "AI Issue"
         uses: cssnr/ai-issue-action@v1

--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "AI Issue"
         uses: cssnr/ai-issue-action@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Debug event.json"
         continue-on-error: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Debug event.json"
         continue-on-error: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Checkout Configs"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: django-files/configs
           ref: master
@@ -48,7 +48,7 @@ jobs:
           cat .pr_agent.toml
 
       - name: "Setup Python"
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Checkout Configs"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: django-files/configs
           ref: master
@@ -48,7 +48,7 @@ jobs:
           cat .pr_agent.toml
 
       - name: "Setup Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6 # v6.0.2
+        uses: actions/checkout@v7 # v7.0.1
 
       - name: "NPM Outdated Action"
         continue-on-error: true

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "NPM Outdated Action"
         continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Debug event.json"
         if: ${{ !cancelled() }}
@@ -41,7 +41,7 @@ jobs:
           cat "${GITHUB_EVENT_PATH}"
 
       - name: "Setup Python 3.14"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
@@ -52,7 +52,7 @@ jobs:
           cache-dependency-glob: "app/requirements-dev.txt"
 
       - name: "Cache Playwright Browsers"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('app/requirements-dev.txt') }}
@@ -70,7 +70,7 @@ jobs:
           uv pip freeze
 
       - name: "Setup Node"
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: "npm"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Debug event.json"
         if: ${{ !cancelled() }}
@@ -41,7 +41,7 @@ jobs:
           cat "${GITHUB_EVENT_PATH}"
 
       - name: "Setup Python 3.14"
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -52,7 +52,7 @@ jobs:
           cache-dependency-glob: "app/requirements-dev.txt"
 
       - name: "Cache Playwright Browsers"
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('app/requirements-dev.txt') }}
@@ -70,7 +70,7 @@ jobs:
           uv pip freeze
 
       - name: "Setup Node"
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "npm"


### PR DESCRIPTION
Bumps first-party GitHub Actions one major version each, reviewed for breaking changes:

- `actions/checkout` v6 → v7
- `actions/setup-node` v6 → v7
- `actions/setup-python` v6 → v7 (removed `pip-install` input — unused here)
- `actions/cache` v4 → v6

No changes to behavior; all currently-used inputs/outputs remain valid per each release changelog.