### PR TITLE
Fix all-in-one image: template app upstream instead of hardcoding app:9000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,12 @@ RUN touch build_sha && echo "${BUILD_SHA}" > build_sha
 ENV TZ=UTC
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV XDG_RUNTIME_DIR=/tmp
-# tusd runs as a local supervisord process in this image, not a separate
-# container — nginx.conf's tusd upstream must be a literal loopback address
-# instead of a hostname (see nginx/60-sign-secret.sh for why).
+# tusd and the app both run as local supervisord processes in this image, not
+# separate containers — nginx.conf's tusd/app upstreams must be literal
+# loopback addresses instead of hostnames (see nginx/60-sign-secret.sh for
+# why: nginx's resolver directive only queries real DNS, never /etc/hosts).
 ENV TUSD_UPSTREAM=127.0.0.1:8080
+ENV APP_UPSTREAM=127.0.0.1:9000
 
 COPY --from=node /work/app/static/dist/ /app/static/dist/
 COPY --from=python /usr/local/lib/python3.14/site-packages/ /usr/local/lib/python3.14/site-packages/

--- a/nginx/60-sign-secret.sh
+++ b/nginx/60-sign-secret.sh
@@ -74,4 +74,15 @@ tusd_upstream="${TUSD_UPSTREAM:-tusd:8080}"
 echo "tusd_upstream: ${tusd_upstream}"
 sed "s/{{tusd_upstream}}/${tusd_upstream}/g" -i /etc/nginx/nginx.conf
 
+# Template the app upstream. Defaults to the app container's service name for
+# the standalone nginx image used by every compose stack, resolvable via
+# Docker's embedded DNS (127.0.0.11) at request time; the all-in-one image's
+# Dockerfile overrides APP_UPSTREAM to a literal 127.0.0.1:9000 (app runs as a
+# local supervisord process there, and the `resolver` directive only queries
+# real DNS servers — it never falls back to /etc/hosts, so the "app" alias
+# added there for other tools doesn't help here).
+app_upstream="${APP_UPSTREAM:-app:9000}"
+echo "app_upstream: ${app_upstream}"
+sed "s/{{app_upstream}}/${app_upstream}/g" -i /etc/nginx/nginx.conf
+
 echo "$0 - Finished"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -164,7 +164,7 @@ http {
         location = /internal/hls-auth {
             internal;
             resolver 127.0.0.11 valid=30s ipv6=off;
-            set $app_upstream app:9000;
+            set $app_upstream {{app_upstream}};
             proxy_pass http://$app_upstream/api/stream/hls-auth/?name=$hls_name&token=$hls_arg_token&sig=$hls_sig&exp=$hls_exp;
             proxy_pass_request_body off;
             proxy_set_header        Content-Length "";
@@ -211,7 +211,7 @@ http {
             client_max_body_size     {{upload_max_size}};
             proxy_request_buffering  off;
             resolver 127.0.0.11 valid=30s ipv6=off;
-            set $app_upstream app:9000;
+            set $app_upstream {{app_upstream}};
             proxy_pass          http://$app_upstream;
             proxy_http_version  1.1;
             proxy_buffering     off;
@@ -232,7 +232,7 @@ http {
         # and IP changes.
         location  /  {
             resolver 127.0.0.11 valid=30s ipv6=off;
-            set $app_upstream app:9000;
+            set $app_upstream {{app_upstream}};
             proxy_pass          http://$app_upstream;
             proxy_http_version  1.1;
             proxy_buffering     off;


### PR DESCRIPTION
## Problem

The all-in-one image is broken since #dbb7501 ("Fix nginx pinning a stale app IP"): nginx logs

    app could not be resolved (3: Host not found)

on every request that hits the `app` upstream (e.g. `/oauth/`).

## Root cause

That commit moved the `app` upstream from a static `proxy_pass http://app:9000` to a `resolver 127.0.0.11 ...; set $app_upstream app:9000;` pattern, to stop nginx from pinning a stale/dead IP across app restarts. That's correct for the compose/swarm stacks, where `app` is a real Docker Compose service name resolvable via Docker's embedded DNS at `127.0.0.11`.

It breaks the all-in-one image, where nginx and the app are supervisord processes in the same container. `docker-entrypoint.sh` only makes `app` resolvable there by adding `127.0.0.1 app redis tusd` to `/etc/hosts` — but nginx's `resolver` directive queries only real DNS servers and never consults `/etc/hosts`, so `app` fails to resolve.

`tusd`'s upstream already handles this correctly: it's templated (`{{tusd_upstream}}`, filled in by `nginx/60-sign-secret.sh` from `$TUSD_UPSTREAM`), with the all-in-one `Dockerfile` overriding it to a literal `127.0.0.1:8080`. The `app` upstream never got the same per-image override — it stayed hardcoded as `app:9000` everywhere.

## Fix

Give `app` the same templating tusd already has:
- `nginx/nginx.conf`: `set $app_upstream app:9000;` → `set $app_upstream {{app_upstream}};` (3 locations)
- `nginx/60-sign-secret.sh`: template `{{app_upstream}}` from `$APP_UPSTREAM` (default `app:9000`, same as tusd)
- `Dockerfile` (all-in-one): `ENV APP_UPSTREAM=127.0.0.1:9000`

Compose/swarm stacks are unaffected — they still default to `app:9000`, resolved via Docker's embedded DNS at request time.

Note: the RTMP `on_publish`/`on_done http://app:9000/...` callbacks are untouched — they resolve via a different nginx-rtmp code path, not the `resolver` directive, so they weren't part of this regression.